### PR TITLE
Fix: lore migration must use addLore (creates WAL), not direct push

### DIFF
--- a/index.html
+++ b/index.html
@@ -1533,9 +1533,15 @@ var CODEX_MIGRATIONS = [
   /* Phase 1 Lore: seed the 4 pre-written governance lore entries from
      docs/snippet-2026-04-15-governance-lore.json, retrofitted from the
      draft shape (volumes[], canon_id) to dissertation-faithful
-     (domain[], references[]). Idempotent via ID check. */
+     (domain[], references[]).
+
+     v2 (bug fix): uses store.addLore() instead of direct push, so WAL
+     entries are created and the seeded entries actually sync to GitHub.
+     v1 shipped with store.lore.push() which bypassed WAL — entries lived
+     only in localStorage cache and got wiped on every fetch.
+     v2 bumps the ID so v1-applied users re-run and recover. */
   {
-    id: 'phase-1-lore-governance-seed-v1',
+    id: 'phase-1-lore-governance-seed-v2',
     run: function() {
       if (!store.lore) store.lore = [];
       var entries = [
@@ -1589,8 +1595,14 @@ var CODEX_MIGRATIONS = [
         }
       ];
       entries.forEach(function(e) {
-        if (!store.lore.some(function(x) { return x.id === e.id; })) {
-          store.lore.push(e);
+        try {
+          // addLore throws on duplicate id — that's the idempotency guard.
+          // It also creates a WAL entry, which is the whole point of this v2.
+          store.addLore(e);
+        } catch(err) {
+          // Duplicate (already present) or validation error — skip silently.
+          // Users affected only if they had v1 applied AND are offline when v2
+          // runs AND have not gone online since. Next online mutation recovers.
         }
       });
     }

--- a/split/codex.html
+++ b/split/codex.html
@@ -1533,9 +1533,15 @@ var CODEX_MIGRATIONS = [
   /* Phase 1 Lore: seed the 4 pre-written governance lore entries from
      docs/snippet-2026-04-15-governance-lore.json, retrofitted from the
      draft shape (volumes[], canon_id) to dissertation-faithful
-     (domain[], references[]). Idempotent via ID check. */
+     (domain[], references[]).
+
+     v2 (bug fix): uses store.addLore() instead of direct push, so WAL
+     entries are created and the seeded entries actually sync to GitHub.
+     v1 shipped with store.lore.push() which bypassed WAL — entries lived
+     only in localStorage cache and got wiped on every fetch.
+     v2 bumps the ID so v1-applied users re-run and recover. */
   {
-    id: 'phase-1-lore-governance-seed-v1',
+    id: 'phase-1-lore-governance-seed-v2',
     run: function() {
       if (!store.lore) store.lore = [];
       var entries = [
@@ -1589,8 +1595,14 @@ var CODEX_MIGRATIONS = [
         }
       ];
       entries.forEach(function(e) {
-        if (!store.lore.some(function(x) { return x.id === e.id; })) {
-          store.lore.push(e);
+        try {
+          // addLore throws on duplicate id — that's the idempotency guard.
+          // It also creates a WAL entry, which is the whole point of this v2.
+          store.addLore(e);
+        } catch(err) {
+          // Duplicate (already present) or validation error — skip silently.
+          // Users affected only if they had v1 applied AND are offline when v2
+          // runs AND have not gone online since. Next online mutation recovers.
         }
       });
     }

--- a/split/index.html
+++ b/split/index.html
@@ -1533,9 +1533,15 @@ var CODEX_MIGRATIONS = [
   /* Phase 1 Lore: seed the 4 pre-written governance lore entries from
      docs/snippet-2026-04-15-governance-lore.json, retrofitted from the
      draft shape (volumes[], canon_id) to dissertation-faithful
-     (domain[], references[]). Idempotent via ID check. */
+     (domain[], references[]).
+
+     v2 (bug fix): uses store.addLore() instead of direct push, so WAL
+     entries are created and the seeded entries actually sync to GitHub.
+     v1 shipped with store.lore.push() which bypassed WAL — entries lived
+     only in localStorage cache and got wiped on every fetch.
+     v2 bumps the ID so v1-applied users re-run and recover. */
   {
-    id: 'phase-1-lore-governance-seed-v1',
+    id: 'phase-1-lore-governance-seed-v2',
     run: function() {
       if (!store.lore) store.lore = [];
       var entries = [
@@ -1589,8 +1595,14 @@ var CODEX_MIGRATIONS = [
         }
       ];
       entries.forEach(function(e) {
-        if (!store.lore.some(function(x) { return x.id === e.id; })) {
-          store.lore.push(e);
+        try {
+          // addLore throws on duplicate id — that's the idempotency guard.
+          // It also creates a WAL entry, which is the whole point of this v2.
+          store.addLore(e);
+        } catch(err) {
+          // Duplicate (already present) or validation error — skip silently.
+          // Users affected only if they had v1 applied AND are offline when v2
+          // runs AND have not gone online since. Next online mutation recovers.
         }
       });
     }

--- a/split/seed.js
+++ b/split/seed.js
@@ -11,9 +11,15 @@ var CODEX_MIGRATIONS = [
   /* Phase 1 Lore: seed the 4 pre-written governance lore entries from
      docs/snippet-2026-04-15-governance-lore.json, retrofitted from the
      draft shape (volumes[], canon_id) to dissertation-faithful
-     (domain[], references[]). Idempotent via ID check. */
+     (domain[], references[]).
+
+     v2 (bug fix): uses store.addLore() instead of direct push, so WAL
+     entries are created and the seeded entries actually sync to GitHub.
+     v1 shipped with store.lore.push() which bypassed WAL — entries lived
+     only in localStorage cache and got wiped on every fetch.
+     v2 bumps the ID so v1-applied users re-run and recover. */
   {
-    id: 'phase-1-lore-governance-seed-v1',
+    id: 'phase-1-lore-governance-seed-v2',
     run: function() {
       if (!store.lore) store.lore = [];
       var entries = [
@@ -67,8 +73,14 @@ var CODEX_MIGRATIONS = [
         }
       ];
       entries.forEach(function(e) {
-        if (!store.lore.some(function(x) { return x.id === e.id; })) {
-          store.lore.push(e);
+        try {
+          // addLore throws on duplicate id — that's the idempotency guard.
+          // It also creates a WAL entry, which is the whole point of this v2.
+          store.addLore(e);
+        } catch(err) {
+          // Duplicate (already present) or validation error — skip silently.
+          // Users affected only if they had v1 applied AND are offline when v2
+          // runs AND have not gone online since. Next online mutation recovers.
         }
       });
     }


### PR DESCRIPTION
## The Bug

Phase 1 Lore's seed migration pushed entries into `store.lore` directly via `store.lore.push()`, bypassing the WAL. Result: the 4 governance entries lived only in localStorage cache and were wiped by every `populateStore` call (bfcache restore, pull-to-refresh, sync). They never synced to GitHub because no WAL entries existed to push.

**Current GitHub state:** `data/canons.json` has `lore: [lore-005-two-shortcuts]` (the manually-imported Cautionary Tale, which went through `store.addLore()` and did push). The 4 seeded entries were visible briefly in-app then vanished on next fetch.

## The Fix

- Migration now calls `store.addLore(entry)` which creates a WAL entry per seeded lore. `flushQueue` pushes them to GitHub on next cycle.
- Bumped migration ID `phase-1-lore-governance-seed-v1` → `-v2` so existing users re-run and recover.
- `addLore` throws on duplicate id — that's the idempotency guard. Wrapped in try/catch.

## Verification

Dry-run confirmed: 4 lore entries added + 4 pending WAL entries created (`lore:create` → `canons.json`). Idempotent on re-run.

## Post-merge expected behavior

1. User hard-refreshes the live app
2. `fetchAll` returns canons.json with [lore-005]
3. Migration v2 runs (not yet applied) → 4 `addLore()` calls → 4 WAL entries pending
4. `flushQueue` fires ~1s later → rebuilds canons.json with all 5 lore entries → pushes
5. User sees 5 lore entries; future refreshes preserve them

https://claude.ai/code/session_016DnK9tQ2iRBzXUaTuqxUYp