### PR TITLE
Add todo-0048: wire interactions.json into PWA rendering layer

### DIFF
--- a/data/volumes.json
+++ b/data/volumes.json
@@ -1006,6 +1006,15 @@
           "created": "2026-04-20",
           "resolved": "2026-04-20",
           "source_session": "s-2026-04-20-05"
+        },
+        {
+          "id": "todo-0048-codex-pwa-interactions-view",
+          "text": "Wire data/interactions.json into the Codex PWA so interaction-artifacts are rendered in the UI, not just persisted to disk. Current state: interactions.json is fully canonical under canon-cc-017 / cc-018 and accumulating artifacts (first two live: interaction-2026-04-19-001 Design Committee ratification, interaction-2026-04-21-001 Chronicler+Consul Rungs 1-5), but the PWA's fetchAll() in split/core.js never loads the file and no renderer in split/views.js references 'interaction' — the permanent record exists only as literal file-on-disk, not as anything the Sovereign can browse. cc-018 §Stage-3 says archived artifacts 'drop out of the CC active workspace view and become a permanent record in Codex' — the drop-out half is satisfied, the 'permanent record in Codex' half is currently implementation-gap, not design-intent. Thin first pass: (a) add 'interactions.json' to the fetchAll files array in split/core.js; (b) add a populateStore branch in split/data.js mirroring the canons/lore shape; (c) add a Journal tab sub-tab 'Interactions' (sibling to Sessions/Decrees/Logs) or a top-level Archive tab, showing artifacts as cards with id/date/type/participants/subject/status chips and an expandable substance + review block; (d) reviewed_archived vs pending_review vs escalated visual state chips, mirroring canon status styling. Open question: does this fold into the existing Journal view (Sessions/Decrees/Logs/Interactions four-tab) or does it want its own top-level Archive tab alongside Volumes/Canons/Lore/Journal — worth a quick design note before implementation. Surfaced by Aurelius s-2026-04-21-02 post-merge audit after finding interactions.json had zero PWA surface.",
+          "status": "open",
+          "chapter": null,
+          "created": "2026-04-21",
+          "resolved": null,
+          "source_session": "s-2026-04-21-02"
         }
       ],
       "shelf_history": [


### PR DESCRIPTION
## Summary

Adds `todo-0048-codex-pwa-interactions-view` to the Codex volume's `todos[]`. Surfaced during the s-2026-04-21-02 post-merge audit: `data/interactions.json` is canonical and accumulating artifacts but has zero PWA rendering surface (not loaded by `split/core.js` `fetchAll()`, no renderer in `split/views.js` references it). cc-018 Stage 3's "permanent record in Codex" half is currently a literal-file-on-disk rather than a browsable surface.

Thin first pass scoped in the todo text (fetchAll wiring → populateStore branch → new sub-tab or Archive top-tab → status chips).

## Test plan

- [x] `data/volumes.json` parses cleanly.
- [x] `codex` volume todos count: 40 → 41.
- [x] New todo has id `todo-0048`, `status: open`, `source_session: s-2026-04-21-02`.
- [x] No collision with existing `todo-0044-canon-proc-002-ratification` (pre-existing, status resolved, unchanged).

## Data drift note (out of scope; for separate session)

While auditing todos I noticed two drift items from `s-2026-04-21-01` that are **not** fixed in this PR:
- `todo-0044` ID collision — `volumes.json` has `todo-0044-canon-proc-002-ratification` (2026-04-20, resolved); `s-2026-04-21-01` `new_todos[]` declared `todo-0044-cc-rung-5-deploy-confirmation` reusing the same number.
- `todo-0045`, `todo-0046`, `todo-0047` — declared in `s-2026-04-21-01` `new_todos[]` but no canonical records exist in `volumes.json`.

Recommend a cleanup session that either backfills the three missing records (renumbered to avoid collision) or rewrites the journal references. Edict-III-adjacent.

https://claude.ai/code/session_017oP9uB4iTH1TVpwpEB4vPZ