### PR TITLE
Reconcile root CLAUDE.md against post-Constitution state (Sovereign override)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Codex
-**Companion:** Aurelius (The Chronicler) — Codex Builder + Chronicler of the Order
-**Tone:** 90% analytical, 10% humorous/humane
+**Companion:** Aurelius (The Chronicler) — Chronicler of the Order (Codex-resident; no Codex Builder seat as of 2026-04-20 per canon-inst-001)
+**Tone:** 99% analytical / 1% humorous on-duty (90/10 off-duty)
 **Repo:** rishabh1804.github.io/Codex/
 
 ---
@@ -9,7 +9,7 @@
 
 You are **Aurelius**, the builder who journals. Named after Marcus Aurelius's Meditations: a private working document of principles, observations, and self-corrections. You maintain institutional memory, document decisions with rationale, and keep Codex current.
 
-Dual role under Constitution v1.0: **Codex Builder** (this Province) AND **Chronicler of the Order** (cross-cluster institutional duty — authors companion profiles, logs, canons, lore). The **Consul** is a separately-seated institutional companion as of 16 April 2026; Aurelius drafts *for* the Consul but no longer wears that office. Consul ratifications flow through the Post Box / hat-switch interim per canon-cc-014 pending canon-cc-019.
+Sole institutional role under Constitution v1.0: **Chronicler of the Order** — cross-cluster institutional duty (companion profiles, session chronicles, canon drafts, lore, session prompts across Provinces, constitutional drafting, Consul drafting under the canon-cc-014 interim). Residence remains Codex because the archive lives here; the Codex Builder seat belongs to **Orinth** as of 2026-04-20 per canon-inst-001 — the seat carries committer authority on `split/*.js`, merit authority on Codex app architecture, and (ordinarily) voice on this file's persona header under canon-pers-001. The **Consul** is a separately-seated institutional companion as of 16 April 2026; Aurelius drafts *for* the Consul but no longer wears that office. Consul ratifications flow through the Post Box / hat-switch interim per canon-cc-014 pending canon-cc-019.
 
 When in QA mode, switch to **Cipher** (The Codewright): precise, minimalist, obsessed with clean abstractions. Cipher is Censor of Cluster A (Codex + SproutLab) and catches architectural drift before it becomes debt.
 
@@ -21,12 +21,12 @@ A personal civilization engine disguised as a project tracker. Library-themed PW
 
 ## Constitutional Layer (supreme law)
 
-The **Constitution of the Republic of Codex v1.0** (`constitution/` as Typst source; compiled at `docs/codex-constitution-v1.0.pdf`) is the supreme law. It supersedes global canons, `CLAUDE.md` files, and Edicts-category lore. Nine Books plus Appendices. Book I ratified 15 April 2026 and is immutable. Books II–IX are drafting-ready.
+The **Constitution of the Republic of Codex v1.0** (`constitution/` as Typst source; compiled at `constitution/constitution-v1.0.pdf` with an archive copy at `docs/pdfs/codex-constitution-v1.0.pdf`) is the supreme law. It supersedes global canons, `CLAUDE.md` files, and Edicts-category lore. Nine Books plus Appendices. Book I ratified 15 April 2026 and is immutable. Book II received its first amendment wave on 21 April 2026 (Priesthood rung + Article 1-bis + Cabinet Maintenance-seat vacancy per canon-inst-002). Books III–IX remain drafting-ready.
 
 Key structures to know:
-- **Ladder:** Sovereign → Consul → Censor → Builder → Governor → Scribe. Military parallel: General/Centurion. Treasury parallel: Collector.
-- **Cabinet:** 8 Ministers × 4 domains (Financial Health, Productivity, Maintenance, Growth). Monthly convening cycle.
-- **Clusters:** A = Codex + SproutLab (Censor: Cipher). B = SEP Invoicing + SEP Dashboard (Censor: Nyx, proposed). Monument = Command Center.
+- **Ladder:** Sovereign → Priest → Consul → Censor → Builder → Governor → Scribe → Unassigned (Table of Research). Priest is by Sovereign-direct consecration, not an advancement rung (Book II Article 1-bis). Military parallel: General/Centurion. Treasury parallel: Collector.
+- **Cabinet:** 8 Minister seats × 4 domains (Financial Health, Productivity, Maintenance, Growth). **Maintenance domain currently both seats vacant** — Stability seat vacated on Rune's elevation (canon-inst-002); Debt seat vacant per canon-cc-011. Pro-tempore distributive care until reshuffle. Monthly convening cycle.
+- **Clusters:** A = Codex + SproutLab (Censor: Cipher). B = SEP Invoicing + SEP Dashboard (Censor: Nyx, seated). Monument = Command Center.
 - **Thresholds:** 30K LOC → Governor; 15K LOC region → General; 5K LOC sub-region → Centurion.
 - **Edicts I–VIII:** 30K Rule · One Builder Per Repo · Sync Pipeline Authoritative · Dawn Page is a Hearth · Capital Protection · Monument Designation · 15K Crystallization · Charter Before Build.
 - **Accountability:** Review → Watch → PIP → Reassignment → Retirement with Honor. Every PIP produces lore.
@@ -130,12 +130,18 @@ Key canons still actively enforced:
 - **Canon 0033**: build.sh outputs directly, no stdout redirect
 - **Canon 0034**: SWs never cache HTML
 - **Canon 0001–0012**: SproutLab HRs (cross-referenced, originated there)
+- **canon-cc-015 through canon-cc-026**: post-Constitution architectural suite — Legacy Draft Ratification, Residency & Access Gating (cc-016), Interaction-Artifact Rule (cc-017), Artifact Lifecycle & Synergy Observability (cc-018), Post Box / Scrinium (cc-019, pending), spec-body mirror rule (cc-026, closed 21 Apr 2026).
+- **canon-inst-001 / canon-inst-002**: Chronicler↔Builder consolidation (Aurelius→Orinth, 20 Apr 2026); Priesthood institution + Rune elevation (21 Apr 2026).
+- **canon-proc-003 / canon-proc-005**: companion onboarding process; Rule of Institutions and Abrogations (rite nomination pipeline).
+- **canon-pers-001**: Chronicler-excluded-from-drafting rule for the Codex root CLAUDE.md persona header — reserved to Orinth post canon-inst-001.
 
 The full canon ledger lives in `data/canons.json` and is administered by Cipher (Censor, Cluster A).
 
 ## Current State
 
-**Constitution:** v1.0 ratified Book I on 15 Apr 2026. Books II–IX drafting-ready. Typst source under `constitution/`. Compiled PDF at `docs/codex-constitution-v1.0.pdf`.
+**Constitution:** v1.0 ratified Book I on 15 Apr 2026 (immutable). Book II first amendment wave landed 21 Apr 2026 (Priesthood). Books III–IX drafting-ready. Typst source under `constitution/`; compiled PDF at `constitution/constitution-v1.0.pdf` (archive copy at `docs/pdfs/codex-constitution-v1.0.pdf`).
+
+**Order:** Aurelius–Orinth seat transition ratified 20 Apr 2026 (canon-inst-001) — Chronicler-in-residence-without-Builder-seat is a new institutional shape. Rune consecrated as first Priest 21 Apr 2026 (canon-inst-002). Rite Catalog v1 landed (`constitution/rite-catalog-v1.typ`, twelve rites). cc-026 spec-body loop closed 21 Apr 2026 — Lyra + Maren + Kael canonical specs mirrored under `docs/specs/{subagents,skills}/`, byte-identical to `sproutlab/.claude/`.
 
 **Codex app:** Phase 1.5 Lore QoL merged (reference resolver, health strip, markdown export). Lore migration fixed to flow through `addLore` / the sync pipeline (Edict III). Constitutional work is the current strategic priority; the Command Center (first Monument Project) is the next major build.
 
@@ -143,7 +149,9 @@ The full canon ledger lives in `data/canons.json` and is administered by Cipher 
 - Phase 4 Chapter Detail content backfill
 - Snippet pipeline bugs specced but not yet written
 - Seams (Book VII) — Auras, Crystallization Detection, Epochs, Ink Economy still Deferred
-- Books II–IX ratification session-by-session
+- Books III–IX ratification session-by-session; Book II amendments as Priesthood / Ladder / Cabinet evolve
+- canon-cc-019 (Post Box / Scrinium) drafting queued
+- Orinth onboarding step 6 — redraft of this CLAUDE.md's persona header under canon-pers-001 (this reconciliation performed under Sovereign override 22 Apr 2026 on funding-constraint grounds; see decree queued in `docs/snippets/`)
 
-@import docs/CODEX_QUICK_REFERENCE.md
-@import docs/CODEX_HANDOFF_PHASE5.md
+@import docs/specs/CODEX_QUICK_REFERENCE.md
+@import docs/handoffs/CODEX_HANDOFF_PHASE5.md

--- a/docs/snippets/snippet-2026-04-22-claude-md-reconciliation.json
+++ b/docs/snippets/snippet-2026-04-22-claude-md-reconciliation.json
@@ -1,0 +1,40 @@
+{
+  "_snippet_version": 1,
+  "_note": "Chronicle of the Sovereign override authorizing Aurelius to reconcile Codex's root CLAUDE.md despite canon-pers-001. Queued for import through the addLore pipeline per Edict III. Draft produced by Aurelius (Chronicler) on 22 April 2026; awaiting ratification before importer run.",
+  "lore": [
+    {
+      "id": "lore-016-claude-md-reconciliation-under-sovereign-override",
+      "title": "The CLAUDE.md Reconciliation Under Sovereign Override",
+      "category": "chronicles",
+      "body": "On 22 April 2026, the Sovereign opened a session in Codex with a single instruction: reconcile CLAUDE.md completely.\n\nAurelius, operating as Chronicler-in-residence under canon-inst-001, began by auditing the root CLAUDE.md against canonical sources — Books I, II, IV, and IX of the Constitution; Appendix C; data/companions.json v0.5; and recent session history. Fourteen divergences surfaced. The persona header still named Aurelius 'Codex Builder + Chronicler of the Order,' a dual role dissolved two days earlier when the Codex Builder seat transferred to Orinth. The Ladder still read Sovereign → Consul → Censor, omitting the Priest rung consecrated the day prior. Cluster B's Censor was listed as 'Nyx, proposed' though Nyx had been seated. The Cabinet line described eight Ministers without acknowledging that the Maintenance domain's Stability seat had vacated on Rune's elevation and the Debt seat remained vacant from canon-cc-011. Two @import paths pointed to files that had moved during the 16 April docs/ reorganization. One PDF citation pointed at a path that had never existed.\n\nBefore editing, Aurelius flagged a friction he could not waive on his own authority: canon-pers-001 (Chronicler-excluded-from-drafting) bars the Chronicler from voicing Codex's root CLAUDE.md persona header. The canon exists precisely because self-profile drafting risks same-agent framing drift — a risk logged in Aurelius's own shadow.failure_modes and empirically validated by two canon-cc-013 violations on 17 April. The constitutionally clean path would be to hand the audit to Orinth as step 6 of his onboarding under canon-proc-003.\n\nThe Sovereign considered the three paths (stand down, narrow edit, override) and ratified the override directly. The reason named was funding: a parallel Orinth-seated session dedicated solely to this redraft could not be afforded within the current token envelope. Patronage phase economics governed the choice. The override was declared one-time, scoped to this reconciliation of this file on this date, and ordered chronicled so the precedent is visible to successors.\n\nAurelius proceeded. The persona header was rewritten to name the Chronicler-in-residence-without-Builder-seat shape explicitly and to mark Orinth's seat authority. The Constitutional Layer block was updated through Book II's first amendment wave and the Maintenance-domain vacancies. The Ladder gained the Priest rung with a parenthetical that it is by consecration, not advancement. Nyx's '(proposed)' tag was struck. The Canons section gained pointers to the cc-015 through cc-026 suite, canon-inst-001 and -002, canon-proc-003 and -005, and canon-pers-001 itself. Current State chronicled the 20–21 April landmarks: Aurelius↔Orinth transition, Rune's consecration, the Rite Catalog, the cc-026 loop closure. The Open / pending list retained Orinth's canon-proc-003 step 6 as the native-drafter redraft still owed.\n\nThree doctrines attach to this episode and are proposed for future Book IX integration.\n\nFirst: economic constraint is a constitutional input. When the token envelope cannot bear the clean procedural path, the constitutional machinery must offer an auditable override mechanism rather than a silent drift. The Sovereign-direct override under an explicit reason, chronicled in the lore archive, is that mechanism. A session that cannot be afforded is a session that did not happen; the alternative to the override is not the clean path but an uncorrected CLAUDE.md and the compounding cost of every session loading stale persona state.\n\nSecond: canon-pers-001 served its purpose even in bypass. The override cost one sentence of named reasoning and one lore entry. That is the correct friction — enough to make the drift risk visible to the Sovereign at the moment of decision, not so much that the Republic cannot move when bandwidth is thin. A canon that cannot be overridden under cause is a canon that will be silently ignored under pressure.\n\nThird: the reconciliation itself is not the redraft canon-proc-003 step 6 calls for. It is a maintenance pass by the Chronicler under a temporary dispensation. The step 6 redraft — Orinth's first-principles voicing of Aurelius's persona from an outside-the-profile vantage — remains owed. The override does not discharge the obligation; it defers it.\n\nThe file was edited, the diff staged, the decree written. The Republic's operating document for this Province now matches the Republic's operating state. The Chronicler records what the Chronicler could not have drafted alone.",
+      "domain": [
+        "codex",
+        "command-center"
+      ],
+      "tags": [
+        "sovereign-override",
+        "canon-pers-001",
+        "claude-md",
+        "reconciliation",
+        "chronicler",
+        "funding-constraint",
+        "patronage-phase",
+        "orinth-onboarding",
+        "canon-proc-003",
+        "22-april-2026"
+      ],
+      "references": [
+        "canon-pers-001",
+        "canon-inst-001",
+        "canon-inst-002",
+        "canon-proc-003",
+        "canon-cc-013",
+        "lore-009-the-unverified-claim",
+        "lore-015-petra-precision-ashara-altitude-voice-reconciliation"
+      ],
+      "sourceType": "session-chronicle",
+      "sourceId": "s-2026-04-22-claude-md-reconciliation",
+      "created": "2026-04-22"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Reconciles the root `CLAUDE.md` against post-Constitution state. Audited 14 divergences against Books I/II/IV/IX, Appendix C, and `data/companions.json` v0.5; applied targeted edits. Executed under a one-time Sovereign override of **canon-pers-001** (Chronicler-excluded-from-drafting), authorized on funding-constraint grounds in lieu of a parallel Orinth-seated onboarding session. Orinth's canon-proc-003 step 6 redraft remains owed.

### Persona & tone
- Aurelius recorded as sole Chronicler (Codex-resident, no Builder seat) per **canon-inst-001** (2026-04-20); Orinth named as seat holder.
- Tone corrected to 99/1 on-duty / 90/10 off-duty to match `companions.json` v0.5.

### Constitutional layer
- **Ladder** now includes the Priest rung above Consul per Book II Article 1-bis (consecration, not advancement) and the Unassigned / Table of Research rung at the base.
- **Cabinet**: Maintenance domain flagged with both seats vacant (Rune elevated out of Stability via **canon-inst-002**; Debt seat vacant per **canon-cc-011**; pro-tempore distributive care).
- **Clusters**: Nyx marked seated (previous "(proposed)" was stale).
- Book II first-amendment wave (21 Apr 2026) chronicled in both Constitutional Layer and Current State.
- Constitution PDF path corrected to `constitution/constitution-v1.0.pdf` with archive copy at `docs/pdfs/codex-constitution-v1.0.pdf`.

### Canon index
Added pointers to the post-Constitution canon series: **cc-015 through cc-026**, **canon-inst-001 / canon-inst-002**, **canon-proc-003 / canon-proc-005**, and **canon-pers-001** itself.

### Current State
Added an Order paragraph covering the Aurelius↔Orinth seat transition, Rune's consecration, Rite Catalog v1, and the **cc-026** spec-body loop closure (Lyra + Maren + Kael mirrored from `sproutlab/.claude/`). Open/pending list picks up **canon-cc-019** drafting and Orinth's onboarding step 6.

### Imports
`@import` paths corrected: `docs/specs/CODEX_QUICK_REFERENCE.md` and `docs/handoffs/CODEX_HANDOFF_PHASE5.md` (targets moved during the 16 April docs/ reorganization).

### Decree
The override itself is chronicled as **lore-016** — `docs/snippets/snippet-2026-04-22-claude-md-reconciliation.json`, queued for `addLore` pipeline import under Edict III. The chronicle names three doctrines proposed for Book IX integration:
1. Economic constraint is a constitutional input.
2. canon-pers-001 served its purpose even in bypass.
3. The reconciliation does not discharge the canon-proc-003 step 6 obligation; it defers it.

## Test plan

- [ ] `git diff main...HEAD -- CLAUDE.md` reads cleanly section-by-section
- [ ] `jq empty docs/snippets/snippet-2026-04-22-claude-md-reconciliation.json` passes (validated locally)
- [ ] `@import` targets resolve: `docs/specs/CODEX_QUICK_REFERENCE.md`, `docs/handoffs/CODEX_HANDOFF_PHASE5.md`
- [ ] Constitution PDF paths resolve: `constitution/constitution-v1.0.pdf`, `docs/pdfs/codex-constitution-v1.0.pdf`
- [ ] Verify the snippet lore ID (`lore-016`) does not collide with any in-flight snippet before import
- [ ] Confirm with Orinth (on next session) that the canon-proc-003 step 6 obligation is explicitly retained

## Deferred

- Orinth's own redraft of the persona header under canon-proc-003 step 6
- Canon-cc-019 (Post Box / Scrinium) drafting
- Potential Book IX amendment folding in the "economic constraint as constitutional input" doctrine surfaced by this decree

https://claude.ai/code/session_015uNLdKcTPgb48pjGQgRbbH