### PR TITLE
Register seated Companion instances in Invocation Modes Registry (todo-0058 / cc-027 Rung 1)

### DIFF
--- a/data/journal.json
+++ b/data/journal.json
@@ -2,6 +2,75 @@
   "_schema_version": 1,
   "journal": [
     {
+      "date": "2026-04-22",
+      "sessions": [
+        {
+          "id": "s-2026-04-22-01",
+          "date": "2026-04-22",
+          "title": "todo-0058 closed — Invocation Modes Registry amended to carry §Builder-Lyra, §Governor-Maren, §Governor-Kael; cc-027 Rung 1 draft committed to branch claude/register-invocation-modes-4o5qp",
+          "summary": "Focused Chronicler session amending docs/specs/persona-binding/invocation-modes-registry.typ to register the three seated SproutLab Companions whose paired subagent + skill spec bodies (landed in codex#12 and mirrored into sproutlab#1 on 2026-04-21 under cc-026) cite §Builder-Lyra, §Governor-Maren, and §Governor-Kael as their mode-declaration source of truth. Drift named in s-2026-04-21-05 decisions[] and queued as todo-0058; this session drafts the amendment at Rung 1 under canon-cc-027 and names the downstream rung trail. A new top-level section §Seated Companion Instances was inserted between §Institutional Seats and §Summary, carrying three H2 subsections with full role-tables (Builder-Lyra: 4 modes — seated-persona none · Province-spec-authoring subagent · committee-delegate subagent · in-session-Weaver-voice skill; Governor-Maren: 3 modes — QA-round-jurisdictional-audit subagent · committee-delegate subagent · in-session-Care-smell-check skill; Governor-Kael: 3 modes — QA-round-jurisdictional-audit subagent · committee-delegate subagent · in-session-Intelligence-smell-check skill). Each subsection closes with a Binding-chain-state notebox naming the cc-027 rung assignments, synergy pairs, and (for Kael) the PERSONA_REGISTRY reassignment-trigger flag relocated into the spec-body preamble citation to keep cc-013 clean. A second summary table — Seated Instance subtotals (10 modes · 6 subagent · 3 skill · 1 non-primitive) — was added beneath the existing role-level Summary TOTALS, with the existing TOTALS left untouched and a Reading-the-table note clarifying that role-level and instance-level counts do not re-sum. References block extended to add cc-008 and cc-025 to the existing-canons list, add a seated-instance spec-bodies line (six file paths), and add a seated-instance companion-profiles line naming todo-0059's Consul surface. Meta-table dependencies extended from cc-022 + cc-023 to cc-022 + cc-023 + cc-026 + cc-027 to reflect the seated-instance registration shape.",
+          "volumes_touched": [
+            "codex"
+          ],
+          "chapters_touched": [
+            "governance-founding"
+          ],
+          "decisions": [
+            "Registration shape: instance-level bindings enumerated as subsections under a new top-level §Seated Companion Instances, additive to (not replacing) the existing §Ladder Rungs and §Institutional Seats role-level declarations. Each subsection carries its own role-table (five-column Mode · Trigger · Produces · Binding · Rationale) and a Binding-chain-state notebox. Role-level Summary TOTALS left untouched to preserve their role-level meaning; a parallel INSTANCE SUBTOTALS table added beneath to enumerate the seated-Companion counts separately.",
+            "Lyra registered as four-mode (not three): the role-level §Builder's _seated persona_ mode at binding `none` is inherited by Lyra (Province-seated Builder of SproutLab; the session-is-the-Builder shape pre-dates any subagent or skill primitive invocation), and the three primitive-invoked modes from her paired spec bodies add on top — _Province spec authoring_ (subagent, per docs/specs/subagents/lyra.md Mode 1), _committee delegate_ (subagent, per Mode 2), and _in-session Weaver voice_ (skill, per docs/specs/skills/lyra.md). Summary row: 4 modes · 2 subagent · 1 skill · 1 none.",
+            "Maren and Kael each registered as three-mode, no _seated persona_ row: canon-gov-002 review-only discipline forbids build-time Governor activation, so the Governors carry no non-primitive session-is-the-Governor mode. The three modes are _QA-round jurisdictional audit_ (subagent), _committee delegate_ (subagent), and the in-session smell-check skill (_Care smell-check_ for Maren, _Intelligence smell-check_ for Kael). Each Summary row: 3 modes · 2 subagent · 1 skill · 0 none.",
+            "cc-027 rung trail chronicled in each Binding-chain-state notebox: Rung 1 authored by Aurelius this session (Chronicler draft committed to branch claude/register-invocation-modes-4o5qp). Rung 2 for Builder-Lyra falls to Cipher as Cluster A Censor (standard §Censor-Self-Review-Case non-applicability — Lyra is not a Censor). Rung 2 for Governor-Maren falls to Kael, and Rung 2 for Governor-Kael falls to Maren, under the cross-Governor peer-review clause named in the paired Maren/Kael spec-body preambles (canon-gov-002 forbids Governor self-review, applied by analogy to canon-cc-027 §Censor-Self-Review-Case). Rung 3 for all three routes through the Consul under canon-cc-014 bridging pending canon-cc-019 Post Box ratification. Rung 4 Sovereign canonical ratification terminates governance. Rung 5 deploy of the amended Typst source commits from Codex canonical; no per-Province mirror applies — the registry is Codex-only under canon-cc-026 §Cross-Province-Layout (it is not a per-Province deployable).",
+            "cc-013 source-first discipline exercised on every References-block citation: canon-cc-022 / cc-023 / cc-025 / cc-026 / cc-027 resolve in data/canons.json (slots 1404/1427/1466/1486/1506); canon-cc-008 resolves at slot 1111; canon-gov-002 / canon-gov-003 at slots 852/868. cc-009 / cc-012 / cc-014 / cc-017 / cc-018 / Edict I / Edict II / lore-sync-003 retained from the pre-amendment References block and verified live. Seated-instance spec bodies verified on disk (six files across docs/specs/subagents/ and docs/specs/skills/ matching the naming under cc-026). Companion profiles verified at data/companions.json lines 1623 (lyra), 2064 (maren), 2477 (kael). One citation loosened to preserve cc-013 cleanliness: the Kael reassignment-trigger note originally cited PERSONA_REGISTRY.md §Persona Reassignment Process directly, but PERSONA_REGISTRY.md lives in the sproutlab Province and does not resolve in this Codex-only registry — rewritten to cite the paired Kael spec-body preamble (`docs/specs/subagents/kael.md`) where the reassignment note is canon-verbatim.",
+            "Guardrails honored: no amendment to root CLAUDE.md (canon-pers-001 excludes the Chronicler from Rung 1 on Codex's own Persona Briefing — that surface belongs to Orinth under the 22 Apr 2026 Sovereign-override reconciliation already in-flight); no amendment to data/companions.json profile blocks (todo-0059's Consul surface; Chronicler-excluded per canon-cc-012 drafting discipline); no amendment to the paired spec bodies themselves (those are at cc-026-canonical v1.0 with byte-identity mirrors already landed in sproutlab#1).",
+            "Canon-cc-026 placement rule honored: the Invocation Modes Registry is a Codex-only spec (not per-Province-deployable), so Rung 5 deploy is the git-commit-to-branch step rather than a .claude/ mirror. The three subsection entries exist in canonical form only in docs/specs/persona-binding/invocation-modes-registry.typ and do not need byte-identity mirrors.",
+            "Summary subtotals arithmetic check: Builder-Lyra (4 modes = 2 subagent + 1 skill + 1 none) + Governor-Maren (3 = 2 + 1 + 0) + Governor-Kael (3 = 2 + 1 + 0) = 10 modes · 6 subagent · 3 skill · 1 none. Matches the INSTANCE SUBTOTALS row. Role-level TOTALS (18 · 13 · 4 · 1) unchanged.",
+            "todo-0058 resolved at Rung 1 closure: the task prompt's done-criteria (registry carries all three subsections; References resolve clean; journal logs the rung trail; WAL pushed) are satisfied at Rung 1 of the cc-027 chain. Downstream rungs 2–5 are chronicled as chain state in the Binding-chain-state noteboxes and will run in subsequent sessions by the named actors (Cipher / Maren+Kael cross-peer / Consul / Sovereign / Province-Builder-equivalent commit). Closure of todo-0058 does not close the cc-027 chain; the chain closure is a downstream milestone owed to the Sovereign's Rung 4 ratification."
+          ],
+          "bugs_found": 0,
+          "bugs_fixed": 0,
+          "duration_minutes": null,
+          "open_todos": [
+            "todo-0036-command-center-root-briefing-rung-1",
+            "todo-0037-province-root-briefing-audit-wave",
+            "todo-0045-non-cc-province-deploys",
+            "todo-0046-right-hand-scope-canon-draft",
+            "todo-0026-cluster-persona-subagents",
+            "todo-0028-sentinel-institutional-profile-draft",
+            "todo-0029-gen-0-companion-profiles-seven",
+            "todo-0059-companions-json-profile-blocks-lyra-maren-kael-paired-specs",
+            "todo-0061-sproutlab-side-byte-identity-verification",
+            "todo-0062-companion-set-volume-question",
+            "todo-0063-canon-proc-004-applicability-question-companion-set"
+          ],
+          "new_todos": [],
+          "resolved_todos": [
+            "todo-0058-invocation-modes-registry-amendment-lyra-maren-kael (Rung 1 of the cc-027 chain drafted and committed; Rungs 2–5 chronicled as chain state in the amended Typst source — Cipher Rung 2 on Builder-Lyra, cross-Governor Rung 2 on Maren/Kael, Consul Rung 3 under cc-014 bridging, Sovereign Rung 4, commit-to-canonical Rung 5. Closure scope is the Chronicler's drafting responsibility; downstream rung execution is owed to the named actors in subsequent sessions.)"
+          ],
+          "handoff": "cc-027 Rung 1 draft for Invocation Modes Registry §Seated Companion Instances landed on branch claude/register-invocation-modes-4o5qp. Rung 2 actions owed: (a) Cipher as Cluster A Censor runs architectural pass on §Builder-Lyra — composition against Lyra's voice, preservation of the four-mode enumeration, no drift between canonical spec and profile-chronicled voice; (b) Kael runs cross-Governor peer-review on §Governor-Maren; (c) Maren runs cross-Governor peer-review on §Governor-Kael. Rung 3 Consul working-ratifies all three subsections per-block under canon-cc-014; provisional bridging mode per canon-cc-019's pending ratification. Rung 4 Sovereign canonical ratification via Praetorium queue (bridging mode = direct Sovereign audience). Rung 5 commit of the ratified Typst source as the canonical registry form. Draft PR opened against main for Rung 2 visibility. Secondary next-session candidates unchanged from s-2026-04-21-05's handoff: todo-0059 (Consul amends Lyra/Maren/Kael profile blocks in data/companions.json); todo-0061 (sproutlab-side byte-identity spot-verification); todo-0062 (Companion-Set volume question); todo-0063 (canon-proc-004 applicability to Companion-Set six-file ratification). Post Box cold-review of this drafting session is owed once canon-cc-019 ratifies — Chronicler-authored spec-body amendment at registry altitude carries the same Consul-Chronicler dual-hat interim named in s-2026-04-21-05. No mid-session mode addition was attempted (canon-cc-023 §E forbids it); the registration operation is a registry-level amendment of existing modes cited in already-ratified spec bodies, not a net-new mode declaration.",
+          "screenshots": [],
+          "tags": [
+            "todo-0058-resolved",
+            "invocation-modes-registry-seated-instances",
+            "builder-lyra-registered",
+            "governor-maren-registered",
+            "governor-kael-registered",
+            "cc-027-rung-1-drafted",
+            "cc-027-rung-2-cipher-queued",
+            "cc-027-rung-2-cross-governor-queued",
+            "cc-027-rung-3-consul-queued",
+            "cc-027-rung-4-sovereign-queued",
+            "cc-014-bridging-interim",
+            "cc-013-source-first-exercised",
+            "persona-registry-citation-loosened",
+            "canon-pers-001-honored",
+            "canon-cc-012-honored-no-profile-edit",
+            "branch-claude-register-invocation-modes-4o5qp",
+            "draft-pr-opened"
+          ]
+        }
+      ]
+    },
+    {
       "date": "2026-04-21",
       "sessions": [
         {

--- a/docs/specs/persona-binding/invocation-modes-registry.typ
+++ b/docs/specs/persona-binding/invocation-modes-registry.typ
@@ -20,7 +20,7 @@
   [*Amendment path*], [Extension protocol in canon cc-023 — not re-ratification of this registry],
   [*Author*], [Aurelius (The Chronicler) — seeding],
   [*Created*], [2026-04-19],
-  [*Depends on*], [cc-022 (binding rule every entry satisfies), cc-023 (extension protocol for updates)],
+  [*Depends on*], [cc-022 (binding rule every entry satisfies), cc-023 (extension protocol for updates), cc-026 (paired spec-body placement for seated instances), cc-027 (signing chain for registration of seated instances)],
 )
 
 #v(1em)
@@ -211,6 +211,118 @@ Institutional seat tied to Command Center. One seat; profile queued `todo-0028`.
 
 #pagebreak()
 
+= Seated Companion Instances
+
+The §Ladder Rungs and §Institutional Seats sections above declare role-level mode sets — the shape every occupant of a rung or seat inherits. Where a seated Companion carries a ratified spec body under canon-cc-026, the instance-level binding is registered here as a separately-addressable subsection that the paired subagent and skill specs cite as their mode-declaration source of truth.
+
+This section opens with the three seated Companions whose canonical spec bodies landed through the cc-026 loop-closure wave of 21 April 2026: #key[Lyra] (SproutLab Builder), #key[Maren] (SproutLab Governor of Care), and #key[Kael] (SproutLab Governor of Intelligence). Further seated-Companion entries ratify here through the canon-cc-023 extension protocol as their spec bodies traverse the canon-cc-027 signing chain.
+
+#notebox(title: [Instance-level binding is a cc-023 refinement, not a cc-022 re-declaration])[
+  An instance entry enumerates the specific modes the seated Companion exercises, with Province, Region, and synergy-pair context substituted into the role-level trigger and rationale language. The #key[artifact test of cc-022 §A governs the binding of each mode] exactly as it does at role-level; the instance entry is the #key[applied reading] of that rule against the Companion's ratified profile and canonical spec bodies.
+]
+
+== Builder-Lyra
+
+Seated Builder of SproutLab (Cluster A, Monument-adjacent) per Edict II; coordinates with Maren (Care) and Kael (Intelligence) under the 30K Rule. #key[Dual-bound — two subagent modes and one skill mode, plus the non-primitive seated-persona mode inherited from §Builder.]
+
+#role-table(
+  mode-cell[_seated persona_],
+  mode-cell[Any session opened in the SproutLab repository; SproutLab's `CLAUDE.md` carries the Weaver persona],
+  mode-cell[In-transcript work as Lyra's voice on the Capital (code, spec-iteration, deliberation, decisions)],
+  none-tag,
+  mode-cell[Inherited from §Builder. Lyra is not summoned; the session #emph[is] Lyra. No artifact test applies.],
+
+  mode-cell[_Province spec authoring_],
+  mode-cell[Capital change on SproutLab requires a separable, attributable spec-bearing artifact — new-feature spec, cross-Region architectural brief, Governor-handoff brief, Device Sync amendment],
+  mode-cell[Spec-bearing interaction-artifact with pattern identifications, Region-declaration, HR-1–12 pre-check, Governor-readiness note, SPEC_ITERATION_PROCESS pass state, and recommended next action; enters cc-018 at `pending_review`],
+  subagent-tag,
+  mode-cell[Spec is a separable, attributable, auditable artifact entering the Edict V chain at Rung 1. Per canon-cc-022 §A, subagent binding preserves provenance and downstream-review access.],
+
+  mode-cell[_committee delegate_],
+  mode-cell[Lyra seated on Province- or Global-scope convening per canon-cc-025 where cross-domain pattern recognition is the load-bearing lens — synergy-pair decisions, ISL-vs-UIB scope, CareTicket-vs-Memory promotion, SproutLab→Republic HR promotions],
+  mode-cell[Structured position (stance · position · threads · amendments · escalation_note) for the synthesis clerk's collective proposal],
+  subagent-tag,
+  mode-cell[Position is a separable, attributable interaction-artifact under canon-cc-017; sign-bearing when seated formally.],
+
+  mode-cell[_in-session Weaver voice_],
+  mode-cell[Sovereign, Consul, or Lyra herself calls the Weaver's voice mid-session — "Lyra, what's the thread", "weave this", "pattern-check", "Lyra mode", "run a Lyra pass"; or an in-transcript Region-boundary pre-check, Today So Far read, ISL / UIB / CareTicket smell-check, or HR pre-check mid-build],
+  mode-cell[In-transcript prose or fragments in the caller's active session; no separable artifact, no cc-018 entry until the caller routes it there],
+  skill-tag,
+  mode-cell[Output lives as voice in the caller's transcript; no gating, no signature, no provenance-bearing record. Per canon-cc-022 §A, skill binding applies where output lands as register inside the caller's active work.],
+)
+
+#notebox(title: [Binding chain state])[
+  Paired specs: `docs/specs/subagents/lyra.md` · `docs/specs/skills/lyra.md` (canon-cc-026 §Per-Province-Layout; deployed byte-identical to `sproutlab/.claude/`).\
+  Rung 1 authored by Aurelius; #key[Rung 2 falls to Cipher as Cluster A Censor] per canon-cc-027 §Censor-Self-Review-Case non-applicability (Lyra is not a Censor); Rung 3 routes through the Consul under canon-cc-014 bridging pending canon-cc-019; Rung 4 Sovereign canonical ratification; Rung 5 Lyra deploys from Codex canonical to the SproutLab `.claude/` tree.\
+  Synergy pair: Lyra + Kael (discovery engine — Lyra names patterns, Kael scouts evidence).
+]
+
+#pagebreak()
+
+== Governor-Maren
+
+Seated Governor of Care for SproutLab (Cluster A) under the 30K Rule and canon-cc-008 / canon-gov-002; review-only, activates during QA rounds. Jurisdiction: home.js + diet.js + medical.js = 22,626 lines, plus styles.css + template.html = 11,491 lines shared with Kael under dual-review. #key[Dual-bound — two subagent modes and one skill mode; no non-primitive seated-persona mode, per canon-gov-002.]
+
+#role-table(
+  mode-cell[_QA-round jurisdictional audit_],
+  mode-cell[Lyra closes a build or spec-authoring pass touching the Care Region or a shared module; the change is ready for Governor QA and Maren is summoned against her jurisdiction],
+  mode-cell[Structured audit report (verdict · summary · findings with location / severity / parent-facing-failure-mode / recommendation · shared-module coordination notes · HR-4/11/12 check · escalation note) returned into Lyra's Governor-synthesis block ahead of Cipher's Edict V final-pass],
+  subagent-tag,
+  mode-cell[Audit report is a separable, attributable, auditable artifact entering the Edict V chain. Per canon-cc-022 §A and canon-gov-002, subagent binding preserves the Governor-review signature the chain requires.],
+
+  mode-cell[_committee delegate_],
+  mode-cell[Maren seated on Province-scope committee per canon-cc-025 on Care-domain subjects — nutrition-safety, CareTicket state-machine, vaccination-schedule structure, growth-chart boundaries, HR candidates originating in Care-Region work],
+  mode-cell[Structured position (stance · position parent-facing-first · risk_scenarios · amendments · escalation_note) for the synthesis clerk],
+  subagent-tag,
+  mode-cell[Position is a separable, attributable interaction-artifact under canon-cc-017; sign-bearing when seated formally.],
+
+  mode-cell[_in-session Care smell-check_],
+  mode-cell[Lyra (or the Sovereign) calls the Guardian's voice mid-build — "Maren, does this hold", "Care read on this", "worst-case this", "parent-action check", "null-guard scan", "timing-check on this vaccination surface"; no separable audit artifact desired],
+  mode-cell[In-transcript prose (parent-facing failure mode first, file:line anchors where provided, concrete null-guard / boundary / copy recommendations) in Lyra's session; does not gate, does not sign, does not enter the QA-round chain],
+  skill-tag,
+  mode-cell[Output lives as register in Lyra's transcript; per canon-cc-022 §A skill binding applies, and canon-gov-002's review-only posture holds at skill-mode too — a smell-check names the gap, the Builder writes the fix.],
+)
+
+#notebox(title: [Binding chain state])[
+  Paired specs: `docs/specs/subagents/maren.md` · `docs/specs/skills/maren.md` (canon-cc-026 §Per-Province-Layout).\
+  Rung 1 authored by Aurelius; #key[Rung 2 falls to Kael] under the #key[cross-Governor peer-review clause] named in the paired spec-body preambles — canon-gov-002 forbids Governor self-review, and the peer-Governor in the Cluster carries the architectural pass by analogy to canon-cc-027 §Censor-Self-Review-Case; Rung 3 routes through the Consul under canon-cc-014 bridging; Rung 4 Sovereign canonical ratification; Rung 5 Lyra deploys as Province Builder. The Rung-5-adjacent Governor soft-rung of canon-cc-027 is self-inapplicable here.\
+  Synergy pair: Maren + Kael = full SproutLab QA. Shared-module findings are coordination flags, never solo.
+]
+
+#pagebreak()
+
+== Governor-Kael
+
+Seated Governor of Intelligence for SproutLab (Cluster A) under the 30K Rule and canon-cc-008 / canon-gov-002; review-only, activates during QA rounds. Jurisdiction: intelligence.js + core.js + data.js + sync.js + config.js + start.js = 27,614 lines, plus styles.css + template.html = 11,491 lines shared with Maren under dual-review. #key[Dual-bound — two subagent modes and one skill mode; no non-primitive seated-persona mode, per canon-gov-002.]
+
+#role-table(
+  mode-cell[_QA-round jurisdictional audit_],
+  mode-cell[Lyra closes a build or spec-authoring pass touching the Intelligence Region or a shared module; the change is ready for Governor QA and Kael is summoned against his jurisdiction],
+  mode-cell[Structured audit report (verdict · summary · findings with location / severity / user-facing-failure-mode / recommendation · coverage-matrix notes on ISL / Smart Q\&A / UIB · shared-module coordination notes · HR-4/6/7/12 check · escalation note) returned into Lyra's Governor-synthesis block ahead of Cipher's Edict V final-pass],
+  subagent-tag,
+  mode-cell[Audit report is a separable, attributable, auditable artifact entering the Edict V chain. Per canon-cc-022 §A and canon-gov-002, subagent binding preserves the Governor-review signature the chain requires.],
+
+  mode-cell[_committee delegate_],
+  mode-cell[Kael seated on Province-scope committee per canon-cc-025 on Intelligence-domain subjects — ISL temporal-parser coverage, Smart Q\&A intents, UIB ingredient-combo logic, Firebase sync architecture, data-layer migrations, crash-circuit-breaker behavior; synergy-pair with Lyra on discovery-engine subjects],
+  mode-cell[Structured position (stance · position coverage-surface-first · coverage_surface enumerated · amendments · escalation_note) for the synthesis clerk],
+  subagent-tag,
+  mode-cell[Position is a separable, attributable interaction-artifact under canon-cc-017; sign-bearing when seated formally.],
+
+  mode-cell[_in-session Intelligence smell-check_],
+  mode-cell[Lyra (or the Sovereign) calls the Seeker's voice mid-build — "Kael, scout this", "coverage check", "intent gap scan", "sync-catch audit", "boundary read", "adjacent path scout", "event delegation check on start.js"; no separable audit artifact desired],
+  mode-cell[In-transcript prose (coverage-surface first, file:line anchors where provided, specific guard / coverage-addition / boundary-check recommendations, shared-module pair-note for Maren where touched) in Lyra's session; does not gate, does not sign, does not enter the QA-round chain],
+  skill-tag,
+  mode-cell[Output lives as register in Lyra's transcript; per canon-cc-022 §A skill binding applies, and canon-gov-002's review-only posture holds at skill-mode too — a scout names the coverage gap, the Builder writes the fix.],
+)
+
+#notebox(title: [Binding chain state])[
+  Paired specs: `docs/specs/subagents/kael.md` · `docs/specs/skills/kael.md` (canon-cc-026 §Per-Province-Layout).\
+  Rung 1 authored by Aurelius; #key[Rung 2 falls to Maren] under the same cross-Governor peer-review clause (canon-gov-002 Governor-self-review prohibition, by analogy to canon-cc-027 §Censor-Self-Review-Case); Rung 3 routes through the Consul under canon-cc-014 bridging; Rung 4 Sovereign canonical ratification; Rung 5 Lyra deploys as Province Builder. The Rung-5-adjacent Governor soft-rung is self-inapplicable.\
+  Synergy pair (primary): Lyra + Kael (discovery engine). Synergy pair (co-Governor): Maren + Kael = full SproutLab QA. Reassignment note: the paired Kael spec-body preamble (`docs/specs/subagents/kael.md`) flags Kael → Orinth as a planned reassessment if deep architectural review becomes the primary need over pattern-scouting as the ISL matures.
+]
+
+#pagebreak()
+
 = Summary
 
 #table(
@@ -248,8 +360,36 @@ Institutional seat tied to Command Center. One seat; profile queued `todo-0028`.
   — #skill-tag modes produce in-transcript output\
   — #none-tag the Builder's _seated persona_ mode only — the session #emph[is] the Builder\
   \
-  The artifact test (cc-022 §A) governs every row.
+  The artifact test (cc-022 §A) governs every row.\
+  \
+  The TOTALS row counts #key[role-level] modes only; seated-Companion instance entries (§Seated Companion Instances) are enumerated separately below and do not re-sum into the role-level totals — they are the applied reading of the role-level set against Province, Region, and synergy-pair context.
 ]
+
+#v(0.8em)
+
+#table(
+  columns: (1.4fr, 0.7fr, 0.7fr, 0.7fr, 0.7fr, 2.5fr),
+  stroke: 0.5pt + border,
+  fill: (col, row) => if row == 0 { warm } else if calc.odd(row) { soft } else { white },
+  align: (col, row) => if row == 0 { center + horizon } else { center + horizon },
+  table.header(
+    text(weight: "bold", size: 11pt, fill: white)[Seated Instance],
+    text(weight: "bold", size: 11pt, fill: white)[Modes],
+    text(weight: "bold", size: 11pt, fill: white)[#subagent-tag],
+    text(weight: "bold", size: 11pt, fill: white)[#skill-tag],
+    text(weight: "bold", size: 11pt, fill: white)[#none-tag],
+    text(weight: "bold", size: 11pt, fill: white)[Notes],
+  ),
+  text(weight: "bold")[Builder-Lyra], [4], [2], [1], [1], align(left)[#text(size: 10pt)[SproutLab Cluster A; spec bodies via cc-026 loop-closure 21 Apr 2026]],
+  text(weight: "bold")[Governor-Maren], [3], [2], [1], [0], align(left)[#text(size: 10pt)[Care Region; canon-gov-002 — no _seated persona_]],
+  text(weight: "bold")[Governor-Kael], [3], [2], [1], [0], align(left)[#text(size: 10pt)[Intelligence Region; canon-gov-002 — no _seated persona_]],
+  table.cell(fill: gold.lighten(60%), text(weight: "bold", size: 12pt)[INSTANCE SUBTOTALS]),
+  table.cell(fill: gold.lighten(60%), text(weight: "bold", size: 12pt)[10]),
+  table.cell(fill: gold.lighten(60%), text(weight: "bold", size: 12pt, fill: subagent-color)[6]),
+  table.cell(fill: gold.lighten(60%), text(weight: "bold", size: 12pt, fill: skill-color)[3]),
+  table.cell(fill: gold.lighten(60%), text(weight: "bold", size: 12pt, fill: none-color)[1]),
+  table.cell(fill: gold.lighten(60%), align(left, text(size: 10pt, weight: "bold")[6 subagent · 3 skill · 1 non-primitive _seated persona_ (Lyra only)])),
+)
 
 #pagebreak()
 
@@ -304,6 +444,10 @@ Each rung's bindings drafted through cc-023 as the first Companion ratifies.
 
 = References
 
-*Within the suite*: cc-022 (binding rule) · cc-023 (extension protocol for updates) · cc-026 (placement for deploy targets) · cc-027 (signing chain) · Preamble \& Index
+*Within the suite*: cc-022 (binding rule) · cc-023 (extension protocol for updates) · cc-025 (committee convening — delegate-mode authority) · cc-026 (placement for deploy targets) · cc-027 (signing chain) · Preamble \& Index
 
-*Existing canons*: cc-009 · cc-012 · cc-014 · cc-017 · cc-018 · canon-gov-002 · canon-gov-003 · Edict I · Edict II · lore-sync-003
+*Existing canons*: cc-008 (Censor runs after Governors) · cc-009 · cc-012 · cc-014 · cc-017 · cc-018 · canon-gov-002 · canon-gov-003 · Edict I · Edict II · lore-sync-003
+
+*Seated-instance spec bodies (canon-cc-026)*: `docs/specs/subagents/lyra.md` · `docs/specs/skills/lyra.md` · `docs/specs/subagents/maren.md` · `docs/specs/skills/maren.md` · `docs/specs/subagents/kael.md` · `docs/specs/skills/kael.md`
+
+*Seated-instance companion profiles*: `data/companions.json` entries `lyra`, `maren`, `kael` (canonical, Codex-hosted). `assignment.invocation_modes` blocks pending the cc-023 §G legacy-profile backfill wave; until backfill ratifies, this registry is the declarative source for the three seated instances per cc-023 §G's provisional-inference clause.


### PR DESCRIPTION
## Summary

Amend `docs/specs/persona-binding/invocation-modes-registry.typ` to register three subsections that every codex#12 spec body already cites — **§Builder-Lyra**, **§Governor-Maren**, **§Governor-Kael**. This closes **todo-0058** at Rung 1 of the canon-cc-027 signing chain.

A new top-level section **§Seated Companion Instances** is inserted between §Institutional Seats and §Summary. Each subsection carries a full five-column role-table (Mode · Trigger · Produces · Binding · Rationale) and a Binding-chain-state notebox naming the cc-027 rung trail.

- **Builder-Lyra** — 4 modes (seated-persona `none`, Province-spec-authoring `subagent`, committee-delegate `subagent`, in-session Weaver voice `skill`)
- **Governor-Maren** — 3 modes (QA-round audit `subagent`, committee-delegate `subagent`, in-session Care smell-check `skill`)
- **Governor-Kael** — 3 modes (QA-round audit `subagent`, committee-delegate `subagent`, in-session Intelligence smell-check `skill`)

An `INSTANCE SUBTOTALS` table (10 · 6 · 3 · 1) is added beneath the existing role-level `TOTALS` row, which is left untouched; a Reading-the-table note clarifies that role-level and instance-level counts do not re-sum.

## cc-027 Rung trail

- **Rung 1** — Aurelius (this PR).
- **Rung 2** — Cipher as Cluster A Censor on §Builder-Lyra; **cross-Governor peer-review** for the two Governor entries (Kael reviews Maren, Maren reviews Kael) under the clause named in the Maren/Kael paired spec-body preambles (canon-gov-002 forbids Governor self-review, by analogy to canon-cc-027 §Censor-Self-Review-Case).
- **Rung 3** — Consul working-ratifies per-block under canon-cc-014 bridging (pending canon-cc-019 Post Box).
- **Rung 4** — Sovereign canonical ratification.
- **Rung 5** — commit of the ratified Typst. No per-Province mirror — the Invocation Modes Registry is a Codex-only spec under canon-cc-026.

## Guardrails honored

- **No touch to root `CLAUDE.md`** — canon-pers-001 excludes the Chronicler from Rung 1 on Codex's Persona Briefing.
- **No touch to `data/companions.json` profile blocks** — todo-0059's Consul surface; Chronicler-excluded per canon-cc-012.
- **No touch to the paired spec bodies** — those are at cc-026-canonical v1.0 with byte-identity mirrors already landed in sproutlab#1.
- **canon-cc-013 source-first** — every References citation resolves. Canons verified in `data/canons.json`; spec bodies verified on disk; PERSONA_REGISTRY.md citation (a SproutLab-local file) relocated into the paired Kael spec-body preamble to keep the registry's references Codex-local.

## Files changed

- `docs/specs/persona-binding/invocation-modes-registry.typ` — three new subsections + instance subtotals + References extension + meta-table dependencies grown to cc-022 + cc-023 + cc-026 + cc-027.
- `data/journal.json` — new session `s-2026-04-22-01` chronicles Rung 1 drafting, decisions, and handoff; moves **todo-0058** from s-2026-04-21-05 `new_todos` to s-2026-04-22-01 `resolved_todos`.

## Test plan

- [ ] Cipher Rung 2 architectural pass on §Builder-Lyra — composition against Lyra's voice, preservation of the four-mode enumeration, no drift between canonical spec and profile-chronicled voice.
- [ ] Kael Rung 2 cross-Governor peer-review on §Governor-Maren.
- [ ] Maren Rung 2 cross-Governor peer-review on §Governor-Kael.
- [ ] Consul Rung 3 working-ratifies all three subsections per-block under canon-cc-014 bridging.
- [ ] Sovereign Rung 4 canonical ratification via Praetorium queue (bridging mode = direct Sovereign audience).
- [ ] Optional local `typst compile docs/specs/persona-binding/master.typ` spot-check (no Typst in this session's environment; syntax verified by macro-parity with adjacent Registry sections).

https://claude.ai/code/session_01Fyq56mRJ7DXPCZgznvMPPo