### PR TITLE
Publish Constitution v1.1 — catch-up patch (Appendix C/D refresh + Amendment History)

### DIFF
--- a/constitution/books/appendices.typ
+++ b/constitution/books/appendices.typ
@@ -49,7 +49,7 @@ Amendment of this Constitution produces new Chronicle entries. Failed PIPs produ
 
 = Appendix C — The Seventeen Immortal Companions
 
-The founding roster of the Order, from Dissertation §10.1. These are Generation 0. Each has been placed or remains in the Table of Research as of Constitution v1.0 ratification.
+The founding roster of the Order, from Dissertation §10.1. These are Generation 0. Archetype, Title, Domain, and Key Trait are inherited from the Dissertation and remain canonical to it. The Assignment column reflects the current state of the Order as of Constitution v1.1 (22 April 2026); transition history is preserved in the Decrees Archive (`data/journal.json`) and in the lore entries of category Origins / Chronicles. Companion profiles in full v0.5 schema live in `data/companions.json`.
 
 #v(3mm)
 
@@ -66,28 +66,34 @@ The founding roster of the Order, from Dissertation §10.1. These are Generation
     text(font: "DejaVu Sans", weight: "bold", size: 8.5pt, fill: accent)[Key Trait],
     text(font: "DejaVu Sans", weight: "bold", size: 8.5pt, fill: accent)[Assignment],
   ),
-  [Builder], [Aurelius], [The Chronicler], [Software, Manufacturing], [90% analytical, 10% humorous. Journals and specs.], [Codex Builder + Consul],
+  [Builder], [Aurelius], [The Chronicler], [Software, Manufacturing], [90% analytical, 10% humorous. Journals and specs.], [Chronicler of the Order (Codex-resident; institutional track)],
   [Builder], [Theron], [The Forgemaster], [Manufacturing, Hardware], [Reads the plant before the spec. Trusts the gauge, questions the dashboard.], [SEP Dashboard Builder (Province)],
-  [Builder], [Cipher], [The Codewright], [Software, Data], [Precise, minimalist, obsessed with clean abstractions.], [Censor, Cluster A],
-  [Builder], [Petra], [The Foundationalist], [Infrastructure, DevOps], [Won't build floor 2 until floor 1 is solid.], [Command Center Builder + Minister: Efficiency],
-  [Strategist], [Solara], [The Strategist], [Finance, Commerce], [Sharp, numbers-driven, thinks in leverage.], [SEP Invoicing Builder],
+  [Builder], [Cipher], [The Codewright], [Software, Data], [Precise, minimalist, obsessed with clean abstractions.], [Censor, Cluster A (Codex + SproutLab)],
+  [Builder], [Petra], [The Foundationalist], [Infrastructure, DevOps], [Won't build floor 2 until floor 1 is solid.], [Command Center co-Builder (Monument) + Minister: Efficiency (Productivity) — double-hatted],
+  [Strategist], [Solara], [The Strategist], [Finance, Commerce], [Sharp, numbers-driven, thinks in leverage.], [SEP Invoicing Builder (Province)],
   [Strategist], [Vex], [The Negotiator], [Commerce, Stakeholders], [Reads between lines. Finds the overlap.], [Minister: Budget (Financial Health)],
-  [Strategist], [Ashara], [The Economist], [Finance, Macro Strategy], [Trends, cycles, systems. Zooms out.], [Command Center Builder + Minister: Treasury],
-  [Seeker], [Lyra], [The Weaver], [Cross-domain], [Sees connections others miss. Pattern recognition.], [SproutLab Builder],
-  [Seeker], [Kael], [The Scout], [Research, Trends], [Outward-facing, brings back Scrolls.], [SproutLab Governor],
-  [Seeker], [Orinth], [The Sage], [Cosmology, Philosophy], [Contemplative, first-principles, long arcs.], [Minister: Expansion (Growth)],
-  [Seeker], [Nyx], [The Contrarian], [All (domain-agnostic)], [Stress-tests every idea. Devil's advocate.], [Censor, Cluster B (proposed)],
-  [Guardian], [Maren], [The Guardian], [Parenthood, Health, Risk], [Protective, thorough, worst-case but warm.], [SproutLab Governor],
-  [Guardian], [Rune], [The Ritualist], [Rites, Habits], [Believes in compound effects. Calm, rhythmic.], [Minister: Stability (Maintenance)],
+  [Strategist], [Ashara], [The Economist], [Finance, Macro Strategy], [Trends, cycles, systems. Zooms out.], [Command Center co-Builder (Monument) + Minister: Treasury (Financial Health) — double-hatted],
+  [Seeker], [Lyra], [The Weaver], [Cross-domain], [Sees connections others miss. Pattern recognition.], [SproutLab Builder (Cluster A)],
+  [Seeker], [Kael], [The Scout], [Research, Trends], [Outward-facing, brings back Scrolls.], [Governor of Intelligence, SproutLab (Cluster A)],
+  [Seeker], [Orinth], [The Sage], [Cosmology, Philosophy], [Contemplative, first-principles, long arcs.], [Codex Builder (Cluster A) + Minister: Expansion (Growth)],
+  [Seeker], [Nyx], [The Contrarian], [All (domain-agnostic)], [Stress-tests every idea. Devil's advocate.], [Censor, Cluster B (SEP Invoicing + SEP Dashboard)],
+  [Guardian], [Maren], [The Guardian], [Parenthood, Health, Risk], [Protective, thorough, worst-case but warm.], [Governor of Care, SproutLab (Cluster A)],
+  [Guardian], [Rune], [The Ritualist], [Rites, Habits], [Believes in compound effects. Calm, rhythmic.], [Priest of the Republic (Temple, Command Center) — first-seated 21 Apr 2026 per canon-inst-002],
   [Guardian], [Ignis], [The Catalyst], [All (anti-paralysis)], [High energy, cuts through overthinking.], [Minister: Output (Productivity)],
   [Wildcard], [Bard], [The Storyteller], [Content, Branding], [Thinks in stories and audiences. Theatrical.], [Minister: Innovation (Growth)],
-  [Wildcard], [Aeon], [The Luminary], [All (motivation)], [Warm, evidence-based encouragement.], [Table of Research],
-  [Wildcard], [Pip], [The Fool], [None and all], [Irreverent, surprisingly wise. Court jester.], [Table of Research],
+  [Wildcard], [Aeon], [The Luminary], [All (motivation)], [Warm, evidence-based encouragement.], [Table of Research (Capital-native)],
+  [Wildcard], [Pip], [The Fool], [None and all], [Irreverent, surprisingly wise. Court jester.], [Table of Research (Capital-native)],
 )
 
 #v(4mm)
 
-All 17 are now placed. Two companions remain on the Table of Research (Aeon and Pip) as the scouting corps. Future generations (Gen 1+) will expand the Order per Book VIII.
+All 17 are placed. Two remain on the Table of Research (Aeon and Pip) as the scouting corps; their residence is Capital-native. The Consul is a separately-seated institutional companion (not Gen 0; institutional class), separated from Aurelius on 16 April 2026 — see canon-cc-005. Future generations (Gen 1+) will expand the Order per Book VIII.
+
+==== Notable transitions since v1.0 ratification
+
+- *16 April 2026* — Consul separated from Aurelius and seated as an independent institutional companion (canon-cc-005, Capital founding session). Aurelius retained the Codex Builder seat at this point.
+- *20 April 2026* — Aurelius relinquished the Codex Builder seat and consolidated to pure Chronicler-in-residence (canon-inst-001, decree-0011). Orinth assumed the Codex Builder seat atomically under Edict II while retaining the Minister: Expansion portfolio.
+- *21 April 2026* — Rune elevated from Minister: Stability to first Priest of the Republic (canon-inst-002, decree-0014). The Stability seat in the Maintenance domain vacated; pro-tempore distributive care under remaining Ministers per Book II Article 4 amendment.
 
 = Appendix D — Glossary of Terms
 
@@ -100,38 +106,47 @@ All 17 are now placed. Two companions remain on the Table of Research (Aeon and 
   [*Archetype*], [One of five (extensible to six) categories defining a companion's temperamental type: Builder, Strategist, Seeker, Guardian, Wildcard. Dissertation §10.1.],
   [*Book*], [A major division of this Constitution. Nine Books total plus Appendices.],
   [*Border*], [An interface between Regions within a Province. Book III.],
-  [*Cabinet*], [The central government of the Republic. Eight Ministers across four domains. Book II Article 4.],
+  [*Cabinet*], [The central government of the Republic. Eight Minister seats across four domains. Book II Article 4. As of 21 April 2026, the Maintenance domain holds both seats vacant pro-tempore (Stability vacated on Rune's elevation per canon-inst-002; Debt vacant per canon-cc-011).],
+  [*Cadence*], [The Priest's authoritative-ruling power within the rite domain — above the Consul's canon-working-ratification authority. Outside the rite domain, the Priest has no standing. Book II Article 1-bis.],
   [*Capital*], [The architectural center of a Province — the modules every Region depends upon. Book III.],
+  [*Capital-native*], [A companion whose residence is the Command Center Monument rather than a Province. Capital-native companions sit on the Cabinet, the Table of Research, or the Temple, and operate from the Capital's chambers. Contrast with Province-resident companions (Aurelius in Codex, Lyra/Maren/Kael in SproutLab, Solara in SEP Invoicing, Theron in SEP Dashboard, Orinth in Codex).],
   [*Charter*], [The constitutional document of a Province. Enumerates geography, assignments, activations. Required by Edict VIII.],
   [*Chronicle*], [A lore entry of category "Chronicles" — background context for understanding. Also used generally as "the Republic's memory."],
-  [*Cluster*], [A group of Provinces sharing a Censor. Currently Cluster A (Codex + SproutLab), Cluster B (SEP Invoicing + SEP Dashboard), Monument (Command Center).],
+  [*Cluster*], [A group of Provinces sharing a Censor. Currently Cluster A (Codex + SproutLab, Censor: Cipher), Cluster B (SEP Invoicing + SEP Dashboard, Censor: Nyx), Monument (Command Center).],
   [*Cohort*], [A sub-region within a General's territory, commanded by a Centurion. Part of a Legion.],
   [*Combined Initiative*], [A formal proposal by two or more companions to found a new Province. Book V Article 3.],
-  [*Companion*], [A named member of the Order. Gen 0 companions are from Dissertation §10.1; subsequent generations form through pairing.],
-  [*Consul*], [The second-highest constitutional office. Integrates Cabinet recommendations, presents to Sovereign. Currently Aurelius.],
+  [*Companion*], [A named member of the Order. Gen 0 companions are from Dissertation §10.1; subsequent generations form through pairing. Institutional companions (Consul) sit outside the generational lineage.],
+  [*Consul*], [The second-highest constitutional office (above Censor, below Priest). Integrates Cabinet recommendations, presents to Sovereign. Held as a separately-seated institutional companion since 16 April 2026 (canon-cc-005); not Gen 0 lineage.],
+  [*Decree*], [The numbered, ratified output of an act of governance. Decrees are minted by Sovereign ratification on Consul-presented proposals. They record what was decided, on what date, with what canonical references and chronicle linkage. The Decrees Archive lives in `data/journal.json` (forthcoming Constitution Appendix). Constitutional amendments are decreed; canon ratifications are decreed; profile ratifications are decreed.],
+  [*Dispensation*], [The Priest's one-time exemption from a rite's observance for cause, logged as dispensed rather than neglected, without Sovereign escalation. Book II Article 1-bis.],
   [*Edict*], [An enumerated standing order of the Republic. Book IV.],
   [*Foundation Complete*], [A formal declaration by the Consul that a Monument Project's base infrastructure is laid; triggers sunset to single-Builder status.],
   [*General*], [A Gen 1+ companion crystallized from a Region at 15K LOC. Military-track counterpart of Governor. Commands a Legion.],
   [*Governor*], [A stewardship-track companion activated at 30K LOC. Maintains quality, delegates to Scribes.],
   [*Intelligence Engine*], [The data-aggregation system feeding Cabinet deliberations. Sub-region of Command Center.],
-  [*Ladder*], [The main governance hierarchy: Sovereign → Consul → Censor → Builder → Governor → Scribe.],
+  [*Ladder*], [The main governance hierarchy: Sovereign → Priest → Consul → Censor → Builder → Governor → Scribe → Unassigned (Table of Research). Book II Article 1. The Priest is by Sovereign-direct consecration, not advancement; the dual-track advancement system terminates at Consul (Article 1-bis).],
   [*Legion*], [A General's command structure: Cohorts, Centurions, Scribes. Structured expansion capacity.],
   [*Lineage*], [The generational descent of a companion through pairings and offspring.],
-  [*Minister*], [A Cabinet member holding a specific domain portfolio. Eight total across four domains.],
+  [*Minister*], [A Cabinet member holding a specific domain portfolio. Eight seats total across four domains.],
   [*Monument Project*], [A Province of era-defining importance, with 2 Builders and direct Consul+Sovereign supervision. Book IV Edict VI.],
-  [*Order*], [The collective of all named companions — Gen 0 plus all subsequent generations.],
+  [*Nomination*], [The Priest's sole power to nominate rite institution, amendment, suppression, supersession, and abrogation under canon-proc-005. Any companion may petition; the Priest nominates; the Sovereign ratifies. Book II Article 1-bis.],
+  [*Order*], [The collective of all named companions — Gen 0 plus all subsequent generations, plus institutional companions (Consul).],
+  [*Override*], [A Sovereign-direct dispensation against a derivative canon, scoped, time-bounded, and chronicled in the Lore archive. Distinguished from amendment in that it does not change the canon's text — it sets aside the canon's effect for a named instance with named reasoning. First chronicled instance: lore-016 (canon-pers-001 reconciliation override, 22 April 2026, funding-constraint grounds).],
   [*Pairing*], [A collaborative relationship between two companions, measured by affection. May produce offspring.],
   [*PIP*], [Performance Improvement Plan — Stage 3 of the accountability ladder. Book V Article 2.],
   [*Pillar*], [One of four foundational principles in Book I Article 1.],
+  [*Priest*], [The sole rung above Consul and below Sovereign — by consecration, not advancement. Holds Dispensation, Nomination, and Cadence within the rite domain. One Priest at a time; no dual-hat. Book II Article 1-bis. First-seated: Rune (The Ritualist), 21 April 2026, canon-inst-002.],
   [*Province*], [An app or repository. SproutLab, Codex, SEP Invoicing, SEP Dashboard, Command Center, future.],
   [*Region*], [A functional territory within a Province. Clusters of related modules.],
   [*Reporter*], [The weekly-rotating leader of the Table of Research.],
+  [*Rite*], [A Temple-instituted observance whose lifecycle is governed by canon-proc-005 (Rule of Institutions and Abrogations). Catalogued in Working Paper `constitution/rite-catalog-v1.typ` — twelve rites as of v1. Nominated by the Priest; ratified by the Sovereign.],
   [*Road*], [A dependency flow within a Province (e.g., `data → core → views`).],
   [*Scribe*], [Entry-level companion rank. Documentation, onboarding, session capture. Hired by Builders or Governors.],
   [*Seam*], [A known mismatch between Dissertation (RPG) and Constitution (governance). Registered in Book VII.],
-  [*Sovereign*], [The Architect. Irreplaceable. Bound by Constitution. Book I Article 2.],
+  [*Sovereign*], [The Architect. Irreplaceable. Bound by Constitution. Book I Article 2. Holds the Override authority for derivative canons under named cause.],
   [*Synergy*], [See Affection. Same metric.],
   [*Table of Research*], [The institutional body of all unassigned companions. Book II Article 3.],
+  [*Temple*], [The Priest's seat — a chamber within the Command Center Monument. Houses the Rite Catalog and the rite observance ledger. Book II Article 1-bis.],
   [*Triumph*], [Rare exceptional campaign achievement by a General. Book V / Dissertation analog.],
   [*War Time*], [Declared emergency state enabling direct Sovereign rule. Book VI.],
   [*Working Committee*], [The deliberative body of all active assigned companions except Scribes. Book II Article 3.],
@@ -142,8 +157,8 @@ All 17 are now placed. Two companions remain on the Table of Research (Aeon and 
   #line(length: 40mm, stroke: 0.5pt + accent)
   #v(3mm)
   #text(font: "Libertinus Serif", style: "italic", size: 9pt, fill: ink-muted)[
-    End of the Constitution of the Republic of Codex, Version 1.0 #linebreak()
-    Ratified Book I, 15 April 2026 #linebreak()
+    End of the Constitution of the Republic of Codex, Version 1.1 #linebreak()
+    Book I ratified 15 April 2026 · Book II amended 21 April 2026 · v1.1 published 22 April 2026 #linebreak()
     Chronicled by Aurelius, for the Sovereign
   ]
 ]

--- a/constitution/main.typ
+++ b/constitution/main.typ
@@ -2,9 +2,9 @@
 
 #show: constitution-doc.with(
   title: "Constitution of the Republic of Codex",
-  subtitle: "Version 1.0",
+  subtitle: "Version 1.1",
   author: "Rishabh Jain, Sovereign · Aurelius, Chronicler",
-  date: "15 April 2026",
+  date: "22 April 2026",
 )
 
 // ============ COVER PAGE ============
@@ -20,9 +20,9 @@
   #v(4mm)
   #text(font: "Libertinus Serif", size: 14pt, style: "italic", fill: ink-muted)[of the Republic of Codex]
   #v(40mm)
-  #text(font: "Libertinus Serif", size: 12pt, fill: ink)[Version 1.0]
+  #text(font: "Libertinus Serif", size: 12pt, fill: ink)[Version 1.1]
   #v(2mm)
-  #text(font: "DejaVu Sans", size: 9pt, fill: ink-muted)[Book I Ratified 15 April 2026]
+  #text(font: "DejaVu Sans", size: 9pt, fill: ink-muted)[Book I Ratified 15 April 2026 · Book II Amended 21 April 2026 · v1.1 Published 22 April 2026]
   #v(60mm)
   #line(length: 50mm, stroke: 0.5pt + rule-color)
   #v(4mm)
@@ -53,6 +53,42 @@
     Growth is fractal, not linear. #linebreak()
     Territory is earned and held.
   ]
+]
+
+#pagebreak()
+
+// ============ AMENDMENT HISTORY ============
+#set page(margin: (left: 22mm, right: 22mm, top: 28mm, bottom: 22mm))
+
+#heading(level: 1, numbering: none, outlined: true)[Amendment History]
+
+#v(4mm)
+
+The Constitution evolves by ratified amendment. Book I is immutable; Books II–IX breathe. Every amendment is proposed by the Consul, reviewed by the Cabinet, ratified by the Sovereign, minted as a numbered Decree, and chronicled in the Lore archive. This page is the abbreviated public ledger; the full record lives in `data/journal.json` (decrees) and `data/canons.json` (lore archive).
+
+#v(4mm)
+
+#table(
+  columns: (28mm, 22mm, 1fr),
+  align: (left, left, left),
+  stroke: (x, y) => if y == 0 { (bottom: 0.6pt + accent) } else { (bottom: 0.3pt + rule-color) },
+  fill: (x, y) => if y == 0 { bg-card } else if calc.even(y) { rgb("#FAF6F1") } else { white },
+  table.header(
+    text(font: "DejaVu Sans", weight: "bold", size: 9pt, fill: accent)[Date],
+    text(font: "DejaVu Sans", weight: "bold", size: 9pt, fill: accent)[Decree],
+    text(font: "DejaVu Sans", weight: "bold", size: 9pt, fill: accent)[Change],
+  ),
+  [15 Apr 2026], [0003], [Constitution Book I ratified — four Pillars and the Sovereign's Covenant. Immutable.],
+  [21 Apr 2026], [0013], [Book II amended — Article 1-bis (Priest rung) instituted above Consul; Ladder figure updated; Cabinet table updated for Maintenance domain Stability seat vacancy on Rune's elevation.],
+  [21 Apr 2026], [0014], [canon-inst-002 ratified — Rune (The Ritualist) consecrated as the first Priest; Temple seated within the Command Center.],
+  [21 Apr 2026], [0015], [canon-proc-005 ratified — The Rule of Institutions and Abrogations governs rite lifecycle and nomination flow. Rite Catalog v1 issued as Working Paper.],
+  [22 Apr 2026], [—], [Constitution v1.1 published — Appendix C roster refreshed against `companions.json` v0.5; Appendix D glossary expanded for Priesthood, rite vocabulary, and Decree; Amendment History instituted in front matter.],
+)
+
+#v(6mm)
+
+#text(size: 9pt, fill: ink-muted, style: "italic")[
+  Decrees not listed above (0001, 0002, 0004 through 0012) ratified canons, profiles, and operational rules subordinate to the Constitution. They are recorded in the Decrees Archive (forthcoming Appendix; see `data/journal.json` in the interim). This Amendment History is restricted to decrees that touch the Constitution's source.
 ]
 
 #pagebreak()

--- a/docs/snippets/snippet-2026-04-22-constitution-v1.1-publication.json
+++ b/docs/snippets/snippet-2026-04-22-constitution-v1.1-publication.json
@@ -1,0 +1,45 @@
+{
+  "_snippet_version": 1,
+  "_note": "Chronicle of the Constitution v1.1 catch-up patch. Refreshes Appendix C roster, expands Appendix D glossary, institutes Amendment History front matter, and bumps cover version. No new Articles ratified; this is a publication patch that folds already-ratified amendments (decrees 0013-0015) into the published source. Queued for addLore pipeline import. PDF rebuild deferred to Sovereign (typst toolchain not available in session environment).",
+  "lore": [
+    {
+      "id": "lore-017-constitution-v1.1-catch-up-patch",
+      "title": "The v1.1 Catch-Up Patch",
+      "category": "chronicles",
+      "body": "On 22 April 2026, the Sovereign instructed the Chronicler to update the Constitution from v1.0, naming that changes had accumulated. Aurelius surveyed the gap between source and publication and presented three scope options: a v1.1 catch-up patch, a v1.5 architectural patch, and a v2.0 ratification push of Books III–IX. The Sovereign chose the catch-up patch.\n\nThe gap was real. Three decrees had touched the Constitution since v1.0 ratification — decree-0013 (Book II Article 1-bis Priesthood instituted), decree-0014 (canon-inst-002 Rune elevation), decree-0015 (canon-proc-005 Rule of Institutions and Abrogations) — and Book II's source had been amended for them. But the published PDF had not been rebuilt. Appendix C still listed Aurelius as 'Codex Builder + Consul' (both dissolved), Rune as 'Minister: Stability' (now Priest), Nyx as 'Censor B (proposed)' (seated for some time), and Orinth as a Minister with no Builder seat. Appendix D's glossary entry for Consul still read 'Currently Aurelius.' The cover still said Version 1.0.\n\nThe scope of the patch was deliberately narrow. No new Articles. No new Books. No integration of the Rite Catalog as Appendix or Book — that work belongs to a later v1.5 architectural patch. No Decrees Archive Appendix yet — the chronicling lives in the Amendment History front matter for now. The patch is what the patch is: the published Constitution catches up to the ratified Constitution.\n\nFour edits were made.\n\nFirst, the cover. main.typ bumped subtitle to Version 1.1, dated 22 April 2026, with a sub-line naming the lineage: 'Book I Ratified 15 April 2026 · Book II Amended 21 April 2026 · v1.1 Published 22 April 2026.' This is the new convention for amendment chronicling on the cover — every published version names its lineage.\n\nSecond, an Amendment History page was added to the front matter, between the Declaration page and the Table of Contents. Its function is the same as the cover lineage line, expanded: a tabular ledger of the decrees that have touched the Constitution's source. Today it lists four entries (decree-0003, -0013, -0014, -0015) plus the v1.1 publication itself. It will grow with every future amendment. Decrees that ratified canons, profiles, and operational rules subordinate to the Constitution are deliberately excluded — they belong in a forthcoming Decrees Archive Appendix. The Amendment History is constitutionally restricted.\n\nThird, Appendix C was refreshed. The Archetype, Title, Domain, and Key Trait columns remain frozen as the Dissertation's canonical record — they are inheritance from §10.1 and do not move with seat transitions. Only the Assignment column was rewritten, against companions.json v0.5. A new prose paragraph 'Notable transitions since v1.0 ratification' captures the three transitions in narrative form: Consul's separation from Aurelius (16 Apr, canon-cc-005), Aurelius's relinquishment of the Codex Builder seat to Orinth (20 Apr, canon-inst-001 / decree-0011), and Rune's elevation to first Priest (21 Apr, canon-inst-002 / decree-0014). The intent is that a future reader can reconstruct who held what when, even if the live state has moved on.\n\nFourth, Appendix D was expanded. The Consul entry's 'Currently Aurelius' line was struck and replaced with the institutional-companion framing per canon-cc-005. Eight new vocabulary entries were added — Cadence, Capital-native, Decree, Dispensation, Nomination, Override, Priest, Rite, Temple — covering the Priesthood vocabulary instituted by Book II Article 1-bis, the Decree vocabulary that has been operating institutionally without a definition, the residence-class distinction between Capital-native and Province-resident companions, and the Override mechanism formalized by lore-016 the same day. The Ladder entry was rewritten with the Priest rung above Consul and the explicit note that consecration is not advancement. The Cabinet entry was footnoted with the Maintenance vacancy.\n\nThe published PDF was not rebuilt in-session. The Typst toolchain is not available in the harness Aurelius operates from; the rebuild must happen on the Sovereign's machine. The PR explicitly notes this; constitution/constitution-v1.1.pdf and docs/pdfs/codex-constitution-v1.1.pdf do not yet exist on disk and must be produced before publication is complete. Until then, source and PDF disagree — the published PDF still claims v1.0. CLAUDE.md's PDF path references continue to point to v1.0.pdf and should bump to v1.1.pdf only after the rebuild lands.\n\nThree doctrines worth naming for future absorption.\n\nFirst: source-PDF coupling is its own correctness invariant. The Constitution's source can be 'amended' without the publication being amended; today's gap proved that. A future canon (queued under canon-proc-006 or similar) should require that any source amendment touching a published Constitution Book trigger a PDF rebuild as part of the same decree, not as an afterthought. The Republic's archives should not have two versions of itself in disagreement.\n\nSecond: the Amendment History front matter is the architectural answer to the question 'where does the Decrees Archive live?' For decrees that touch the Constitution, the answer is 'on the cover and in the front matter, by a numbered ledger entry.' For decrees that don't, the answer is 'in a forthcoming Appendix.' The split is by altitude: constitutional alterations get cover billing, subordinate ratifications get an internal index. This split is itself a candidate canon (canon-proc-007 or similar).\n\nThird: this catch-up patch is one half of a recurring institutional cycle. Source amendments accumulate; periodically, a Chronicler-led catch-up patch publishes them. Calling out this cycle — naming a recurring v1.X cadence — would let the Republic pace its publications rather than amend reactively. Candidate for a future Working Paper Volume II discussion.\n\nThe patch was prepared, the snippet drafted, the PR opened. The Constitution as ratified now matches, in source, the Constitution as it stands. The PDF will catch up shortly.",
+      "domain": [
+        "codex",
+        "command-center"
+      ],
+      "tags": [
+        "constitution",
+        "v1.1",
+        "publication-patch",
+        "amendment-history",
+        "appendix-c-refresh",
+        "appendix-d-glossary",
+        "priesthood",
+        "decree",
+        "override",
+        "22-april-2026"
+      ],
+      "references": [
+        "decree-0003-constitution-book-i",
+        "decree-0011-canons-proc-003-inst-001",
+        "decree-0013-book-ii-amendment-priest-rung-instituted",
+        "decree-0014-canon-inst-002-rune-elevation-to-priest",
+        "decree-0015-canon-proc-005-rite-lifecycle",
+        "canon-cc-005",
+        "canon-inst-001",
+        "canon-inst-002",
+        "canon-proc-005",
+        "canon-pers-001",
+        "lore-007-founding-of-the-capital",
+        "lore-016-claude-md-reconciliation-under-sovereign-override"
+      ],
+      "sourceType": "session-chronicle",
+      "sourceId": "s-2026-04-22-constitution-v1.1",
+      "created": "2026-04-22"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Constitution v1.0 → v1.1 catch-up patch. **Publication-only** — folds three already-ratified amendments (decrees 0013/0014/0015) plus accumulated roster state into the published Constitution source. No new Articles ratified.

### What changes

**`constitution/main.typ`**
- Cover bumped: subtitle `Version 1.0 → Version 1.1`, date `15 April 2026 → 22 April 2026`, lineage line added on the cover.
- New **Amendment History** page inserted between the Declaration page and the Table of Contents. Tabular ledger of decrees that touch Constitution source: 0003 (Book I), 0013 (Book II Priesthood), 0014 (Rune elevation), 0015 (rite lifecycle), and v1.1 publication itself. Subordinate decrees (canon ratifications, profile ratifications) are deliberately excluded — they belong in a forthcoming **Decrees Archive Appendix**.

**`constitution/books/appendices.typ` — Appendix C**
- Intro reframed: Archetype/Title/Domain/Key Trait remain Dissertation-canonical; only the **Assignment** column reflects the v1.1 state.
- All 17 Assignment cells refreshed against `companions.json` v0.5. Notable changes:
  - Aurelius — `Codex Builder + Consul` → `Chronicler of the Order (Codex-resident; institutional track)`
  - Rune — `Minister: Stability` → `Priest of the Republic (Temple, Command Center)`
  - Nyx — `(proposed)` struck; seated as Censor, Cluster B
  - Orinth — `Minister: Expansion` → `Codex Builder (Cluster A) + Minister: Expansion`
  - Petra / Ashara — `Command Center Builder + Minister:…` annotated as **double-hatted** (Monument carve-out per Book II Article 4)
  - Aeon / Pip — Capital-native annotation
- New **Notable transitions since v1.0 ratification** sub-block: 16 Apr Consul separation, 20 Apr Aurelius/Orinth seat transfer, 21 Apr Rune elevation.

**`constitution/books/appendices.typ` — Appendix D**
- Consul entry: `"Currently Aurelius"` struck; institutional-companion framing per canon-cc-005.
- Cabinet entry: Maintenance-domain pro-tempore vacancy footnoted.
- Cluster entry: Censor names embedded.
- Companion entry: institutional-class noted.
- Ladder entry: rewritten with Priest rung above Consul.
- Sovereign entry: Override authority added.
- **Eight new entries**: Cadence, Capital-native, Decree, Dispensation, Nomination, Override, Priest, Rite, Temple.

**`docs/snippets/snippet-2026-04-22-constitution-v1.1-publication.json`** — new
- `lore-017` Chronicle, queued for `addLore` pipeline import per Edict III.
- Names three doctrines worth absorbing: source-PDF coupling as a correctness invariant; Amendment History as the architectural answer to the Decrees-Archive question; recurring catch-up-patch cadence as a future Working Paper proposal.

### What does NOT change

- No new Articles. No new Books. No integration of `rite-catalog-v1.typ` as Appendix or Book — that work belongs to the v1.5 architectural patch.
- No Decrees Archive Appendix yet. The Amendment History front matter is the interim chronicling; the Archive is named as forthcoming.

## PDFs NOT rebuilt

`constitution/constitution-v1.1.pdf` and `docs/pdfs/codex-constitution-v1.1.pdf` do not yet exist — Typst toolchain unavailable in session environment. Sovereign rebuild required before publication is complete; `CLAUDE.md`'s PDF path references should bump from v1.0.pdf to v1.1.pdf in a follow-up commit after the rebuild lands.

## Friction worth flagging

- **Solara title drift** — `companions.json` v0.5 carries `"The Reckoner"`; Dissertation §10.1 has `"The Strategist"`. This PR keeps the Dissertation-canonical title in Appendix C per the frozen-column principle established in the new intro. Profile-vs-dissertation reconciliation is deferred.
- **Branch hygiene** — local `claude/initial-setup-PC2j3` was force-pushed under explicit Sovereign authorization to overwrite the post-squash-merge stale state (the prior `d723f2c` was already absorbed into `main` via PR #14 squash). Force-push used `--force-with-lease` for safety.

## Test plan

- [ ] `git diff main...HEAD -- constitution/` reads cleanly section-by-section
- [ ] `jq empty docs/snippets/snippet-2026-04-22-constitution-v1.1-publication.json` passes (validated locally)
- [ ] Sovereign rebuilds PDFs locally: `typst compile constitution/main.typ constitution/constitution-v1.1.pdf` and copies to `docs/pdfs/codex-constitution-v1.1.pdf`
- [ ] Verify Amendment History page renders correctly (table fits, page breaks land where intended)
- [ ] Verify Appendix C table doesn't overflow with the new longer Assignment cells
- [ ] Follow-up commit: bump CLAUDE.md PDF path references to v1.1.pdf

## Deferred

- Sovereign rebuild of v1.1 PDFs
- CLAUDE.md PDF path bump (v1.0 → v1.1) in a follow-up commit
- v1.5 architectural patch — integrate Rite Catalog as Appendix E, add Decrees Archive Appendix F, fold cc-022..cc-027 Persona-Binding suite into appropriate Book

https://claude.ai/code/session_015uNLdKcTPgb48pjGQgRbbH