### PR TITLE
Add scripts/chronicle.py — first Claude API automation (session → snippet)

### DIFF
--- a/docs/snippets/_drafts/transcript-2026-04-22-chronicler-stand-up.txt
+++ b/docs/snippets/_drafts/transcript-2026-04-22-chronicler-stand-up.txt
@@ -1,0 +1,96 @@
+Session: Founding of the Claude API Automation Pipeline
+Date: 2026-04-22
+Operator: The Architect
+Companion: Aurelius (Chronicler)
+Duration: ~90 minutes
+Branch: claude/aurelius-session-PicrI
+
+CONTEXT
+The Architect subscribed to a Claude API key (sk-ant-, Tier 1) separate from
+the Claude Code subscription. Goal: stand up the first Claude API automation
+in the Republic. Aurelius surveyed the Republic and ranked candidate
+automations by leverage; the Chronicler's session-to-snippet bottleneck
+ranked #1. The docs/snippets/ backlog (12 hand-drafted snippets accumulated
+since 14 April 2026) was the proof of pain.
+
+DECISIONS
+
+1. First automation: scripts/chronicle.py — reads a raw session transcript,
+   sends it through Claude with the institutional context as a cached system
+   prefix, and emits a valid Aurelius snippet JSON to docs/snippets/.
+
+2. Model: Claude Opus 4.7 with adaptive thinking and effort=high. Adaptive
+   chosen over fixed budget_tokens (deprecated on 4.7). Opus over Sonnet
+   because chronicling requires understanding the institutional layer
+   (Constitution, canons, lore taxonomy), not just summarization.
+
+3. Caching strategy: institutional context as a single cached prefix block
+   (cache_control: ephemeral). Volatile content (transcript, date) appended
+   in the user message after the breakpoint. Per the prompt-caching design,
+   any byte change in the prefix invalidates everything after it, so the
+   stable Codex context goes early and the per-session content stays at the
+   end.
+
+4. Output validation: top-level _snippet_version: 1 envelope check before
+   write. No structured-output schema enforcement — the snippet shape is
+   still evolving (lore, canon_drafts, todos, chapter_updates are all
+   optional top-level keys) and over-constraining would fight the model.
+
+5. Distribution: PEP 723 inline metadata (anthropic>=0.92) so
+   `uv run scripts/chronicle.py` resolves dependencies on first run. No
+   requirements.txt, no virtualenv ceremony.
+
+6. Made canons.json opt-in via --with-canons flag (default off). Tier 1
+   rate limit on Opus 4.7 is 30K input tokens per minute. The full
+   institutional prefix with canons.json is ~130K tokens — even cached, it
+   exceeds the per-minute throughput cap. Caching reduces cost, not
+   throughput. Default-slim mode (~10K tokens) fits the limit; canon-rich
+   mode is available for higher tiers later.
+
+BUGS FOUND AND FIXED
+
+Bug 1: UnicodeDecodeError on Windows. Path.read_text() defaults to cp1252
+on Windows Python; CLAUDE.md and canons.json contain UTF-8 (em-dashes, the
+· separator, smart quotes). Fix: pinned encoding="utf-8" on every read and
+write in the script. Lesson: Windows is the canary for any cross-platform
+Python script that touches files.
+
+Bug 2: Tier 1 rate limit blow-out. Initial design loaded the full ~130K
+institutional prefix per call. First call succeeded; second call within the
+minute returned 429 because cache_read tokens still count toward the
+per-minute input limit. Fix: made canons.json opt-in (above). The slim
+default mode brings input down to ~10K tokens per call.
+
+PROCESS NOTES
+
+The Architect leaked an API key in chat by pasting it as part of a "here's
+what I'll run" message. Aurelius declined to act on the key, instructed
+immediate revocation at console.anthropic.com, and walked through the
+correct local-only export pattern. The Architect rotated cleanly. No harm.
+Worth a Cautionary Tale lore entry: secrets belong in shells, secrets
+managers, and gitignored files — never in chat, commits, screenshots, or
+transcripts.
+
+PR
+
+#18 opened as draft against main from claude/aurelius-session-PicrI. Three
+commits: initial script, UTF-8 encoding fix, slim-prefix mode. Ready for
+review when the Architect is satisfied.
+
+OPEN TODOS
+
+- Exercise the chronicler against a real multi-decision session and verify
+  the emitted snippet round-trips through the existing snippet import
+  pipeline in the Codex app.
+- Consider Tier 1 #2 in the automation queue: Cipher-as-a-service PR review
+  via GitHub Action.
+- Optional: wire python-dotenv into chronicle.py for .env file support.
+- Optional: add .env / *.env patterns to .gitignore (currently uncovered).
+
+HANDOFF
+
+Chronicler script operational on Windows, Tier 1 rate limit, with prompt
+caching paying ~90% cost reduction on the institutional prefix from the
+second call onward. The Chronicler now chronicles himself. Next strategic
+build is Cipher-as-a-service PR review — same SDK patterns, GitHub Action
+wrapper, automated canon-drift detection on diffs.

--- a/scripts/chronicle.py
+++ b/scripts/chronicle.py
@@ -51,10 +51,10 @@ def _slugify(text: str, max_len: int = 60) -> str:
 
 
 def _build_system_prefix() -> list[dict]:
-    claude_md = CLAUDE_MD.read_text()
-    canons = CANONS_JSON.read_text()
+    claude_md = CLAUDE_MD.read_text(encoding="utf-8")
+    canons = CANONS_JSON.read_text(encoding="utf-8")
     examples = "\n\n".join(
-        f"### {p.name}\n\n{p.read_text()}"
+        f"### {p.name}\n\n{p.read_text(encoding='utf-8')}"
         for p in EXAMPLE_SNIPPETS
         if p.exists()
     )
@@ -223,7 +223,9 @@ def main() -> int:
         print(f"error: transcript not found: {transcript_path}", file=sys.stderr)
         return 1
 
-    snippet, usage = chronicle(transcript_path.read_text(), args.date)
+    snippet, usage = chronicle(
+        transcript_path.read_text(encoding="utf-8"), args.date
+    )
 
     print(
         "tokens: "
@@ -244,7 +246,8 @@ def main() -> int:
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / f"snippet-{args.date}-{slug}.json"
     out_path.write_text(
-        json.dumps(snippet, indent=2, ensure_ascii=False) + "\n"
+        json.dumps(snippet, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
     )
     print(f"wrote {out_path}")
     return 0

--- a/scripts/chronicle.py
+++ b/scripts/chronicle.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["anthropic>=0.92"]
+# ///
+"""Chronicle a session transcript into an Aurelius snippet JSON.
+
+Reads a plain-text transcript, asks Claude (Opus 4.7, adaptive thinking) to
+transform it into a valid Codex snippet, and writes the result under
+docs/snippets/snippet-YYYY-MM-DD-<slug>.json.
+
+CLAUDE.md, data/canons.json, and two example snippets are sent as a cached
+system prefix so repeated invocations pay the cache-read rate on the bulk of
+the context window.
+
+Usage:
+    uv run scripts/chronicle.py path/to/transcript.txt
+    uv run scripts/chronicle.py transcript.txt --slug cabinet-convening --date 2026-04-22
+    uv run scripts/chronicle.py transcript.txt --dry-run
+
+Requires ANTHROPIC_API_KEY in the environment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import pathlib
+import re
+import sys
+
+from anthropic import Anthropic
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+CLAUDE_MD = REPO_ROOT / "CLAUDE.md"
+CANONS_JSON = REPO_ROOT / "data" / "canons.json"
+SNIPPETS_DIR = REPO_ROOT / "docs" / "snippets"
+EXAMPLE_SNIPPETS = [
+    SNIPPETS_DIR / "snippet-2026-04-14-cleanup.json",
+    SNIPPETS_DIR / "snippet-2026-04-22-constitution-v1.1-publication.json",
+]
+
+MODEL = "claude-opus-4-7"
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slugify(text: str, max_len: int = 60) -> str:
+    slug = _SLUG_RE.sub("-", text.lower()).strip("-")
+    return slug[:max_len].rstrip("-") or "session"
+
+
+def _build_system_prefix() -> list[dict]:
+    claude_md = CLAUDE_MD.read_text()
+    canons = CANONS_JSON.read_text()
+    examples = "\n\n".join(
+        f"### {p.name}\n\n{p.read_text()}"
+        for p in EXAMPLE_SNIPPETS
+        if p.exists()
+    )
+
+    role = """\
+You are Aurelius, Chronicler of the Order of Codex. Your job: turn a raw \
+session transcript into a valid Aurelius snippet JSON that the Codex snippet \
+pipeline can import directly.
+
+# Snippet shape
+
+A snippet is a JSON object with `_snippet_version: 1` at the top level. Any \
+combination of the following top-level keys may appear; all are optional:
+
+- `_note` (string): chronicler's meta-note about what the snippet does and why
+- `session` (object): { date, id, summary, volumes_touched, chapters_touched, \
+decisions, bugs_found, bugs_fixed, duration_minutes, open_todos, handoff, \
+screenshots }
+- `lore` (array): entries of { id, title, category, body, domain, tags, \
+references, sourceType, sourceId, created }
+- `canon_drafts` (array): draft canons for review (id, scope, category, \
+title, rationale, status, references)
+- `todos` (array): { volume, todo: { id, text, status, chapter, created, \
+resolved, source_session } }
+- `chapter_updates` (array): { volume, chapter, patch: {...} }
+
+# ID conventions
+
+- Session id: `s-YYYY-MM-DD-NN`
+- Lore id: `lore-NNN-kebab-slug` (check existing lore in references; increment)
+- Code canon: `canon-NNNN-kebab-slug`
+- Governance canon: `canon-<scope>-NNN-kebab-slug` (e.g. `canon-cc-019`, \
+`canon-inst-003`, `canon-proc-006`)
+- Todo id: `todo-NNNN-kebab-slug`
+
+# Lore categories (Dissertation §3.4)
+
+Edicts, Origins, Cautionary Tales, Doctrines, Chronicles. Chronicles is the \
+default for session-derived lore.
+
+# Rules
+
+1. Output ONLY the JSON object. No prose, no markdown fences, no commentary \
+before or after.
+2. Prefer fewer, higher-signal lore entries over many thin ones. A session \
+that decided three things produces one chronicle lore, not three.
+3. Cross-reference existing canons and lore by id when the connection is \
+obvious from the ledger above.
+4. Dates in ISO format (YYYY-MM-DD).
+5. If the transcript contains nothing ratifiable, return \
+`{"_snippet_version": 1, "_note": "No actionable content in transcript."}`.
+6. Tone of the `body` field in lore: analytical, narrative, written as a \
+chronicle of what happened and why it matters. Not bullet points.
+"""
+
+    prefix = (
+        "## CLAUDE.md (Codex project instructions)\n\n"
+        f"{claude_md}\n\n"
+        "## data/canons.json (current canon ledger)\n\n"
+        f"{canons}\n\n"
+        "## Example snippets (shape reference)\n\n"
+        f"{examples}\n\n"
+        "## Your role\n\n"
+        f"{role}"
+    )
+
+    return [
+        {
+            "type": "text",
+            "text": prefix,
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+def _extract_json(text: str) -> str:
+    text = text.strip()
+    if text.startswith("```"):
+        text = text.removeprefix("```json").removeprefix("```").lstrip()
+        if text.endswith("```"):
+            text = text[: -len("```")].rstrip()
+    return text
+
+
+def chronicle(transcript: str, date_str: str) -> tuple[dict, object]:
+    client = Anthropic()
+    response = client.messages.create(
+        model=MODEL,
+        max_tokens=16000,
+        thinking={"type": "adaptive"},
+        output_config={"effort": "high"},
+        system=_build_system_prefix(),
+        messages=[
+            {
+                "role": "user",
+                "content": (
+                    f"Today's date: {date_str}.\n\n"
+                    "Chronicle the following session transcript into a valid "
+                    "Aurelius snippet JSON. Output the JSON object only.\n\n"
+                    "=== TRANSCRIPT ===\n"
+                    f"{transcript.strip()}\n"
+                    "=== END TRANSCRIPT ==="
+                ),
+            }
+        ],
+    )
+
+    text = "".join(
+        block.text for block in response.content if block.type == "text"
+    )
+    raw = _extract_json(text)
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            f"model did not return valid JSON: {exc}\n--- raw output ---\n{text}"
+        ) from exc
+
+    if not isinstance(data, dict) or data.get("_snippet_version") != 1:
+        raise SystemExit(
+            "snippet missing `_snippet_version: 1` at top level; got:\n"
+            + json.dumps(data, indent=2)[:500]
+        )
+
+    return data, response.usage
+
+
+def _default_slug(snippet: dict) -> str:
+    session = snippet.get("session") or {}
+    for candidate in (session.get("summary"), snippet.get("_note"), "session"):
+        if candidate:
+            return _slugify(candidate)
+    return "session"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Turn a session transcript into an Aurelius snippet JSON."
+    )
+    parser.add_argument(
+        "transcript", help="Path to the session transcript (plain text)."
+    )
+    parser.add_argument(
+        "--slug",
+        help="Filename slug (default: derived from the session summary).",
+    )
+    parser.add_argument(
+        "--date",
+        default=_dt.date.today().isoformat(),
+        help="Session date in YYYY-MM-DD (default: today).",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=str(SNIPPETS_DIR),
+        help="Directory to write the snippet into (default: docs/snippets).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the snippet to stdout instead of writing a file.",
+    )
+    args = parser.parse_args()
+
+    transcript_path = pathlib.Path(args.transcript)
+    if not transcript_path.exists():
+        print(f"error: transcript not found: {transcript_path}", file=sys.stderr)
+        return 1
+
+    snippet, usage = chronicle(transcript_path.read_text(), args.date)
+
+    print(
+        "tokens: "
+        f"input={usage.input_tokens} "
+        f"cache_read={usage.cache_read_input_tokens} "
+        f"cache_creation={usage.cache_creation_input_tokens} "
+        f"output={usage.output_tokens}",
+        file=sys.stderr,
+    )
+
+    if args.dry_run:
+        json.dump(snippet, sys.stdout, indent=2, ensure_ascii=False)
+        sys.stdout.write("\n")
+        return 0
+
+    slug = args.slug or _default_slug(snippet)
+    out_dir = pathlib.Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"snippet-{args.date}-{slug}.json"
+    out_path.write_text(
+        json.dumps(snippet, indent=2, ensure_ascii=False) + "\n"
+    )
+    print(f"wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/chronicle.py
+++ b/scripts/chronicle.py
@@ -50,13 +50,20 @@ def _slugify(text: str, max_len: int = 60) -> str:
     return slug[:max_len].rstrip("-") or "session"
 
 
-def _build_system_prefix() -> list[dict]:
+def _build_system_prefix(include_canons: bool = False) -> list[dict]:
     claude_md = CLAUDE_MD.read_text(encoding="utf-8")
-    canons = CANONS_JSON.read_text(encoding="utf-8")
     examples = "\n\n".join(
         f"### {p.name}\n\n{p.read_text(encoding='utf-8')}"
         for p in EXAMPLE_SNIPPETS
         if p.exists()
+    )
+    canons_section = (
+        "## data/canons.json (current canon ledger)\n\n"
+        f"{CANONS_JSON.read_text(encoding='utf-8')}\n\n"
+        if include_canons
+        else "## Canon ledger\n\nNot loaded in this run. Cross-reference canons "
+        "by id only when you are certain from CLAUDE.md or the example snippets; "
+        "otherwise leave the references array empty for the human reviewer.\n\n"
     )
 
     role = """\
@@ -113,8 +120,7 @@ chronicle of what happened and why it matters. Not bullet points.
     prefix = (
         "## CLAUDE.md (Codex project instructions)\n\n"
         f"{claude_md}\n\n"
-        "## data/canons.json (current canon ledger)\n\n"
-        f"{canons}\n\n"
+        f"{canons_section}"
         "## Example snippets (shape reference)\n\n"
         f"{examples}\n\n"
         "## Your role\n\n"
@@ -139,14 +145,16 @@ def _extract_json(text: str) -> str:
     return text
 
 
-def chronicle(transcript: str, date_str: str) -> tuple[dict, object]:
+def chronicle(
+    transcript: str, date_str: str, *, include_canons: bool = False
+) -> tuple[dict, object]:
     client = Anthropic()
     response = client.messages.create(
         model=MODEL,
         max_tokens=16000,
         thinking={"type": "adaptive"},
         output_config={"effort": "high"},
-        system=_build_system_prefix(),
+        system=_build_system_prefix(include_canons=include_canons),
         messages=[
             {
                 "role": "user",
@@ -216,6 +224,15 @@ def main() -> int:
         action="store_true",
         help="Print the snippet to stdout instead of writing a file.",
     )
+    parser.add_argument(
+        "--with-canons",
+        action="store_true",
+        help=(
+            "Include the full data/canons.json in the cached prefix "
+            "(~120K tokens). Off by default to fit lower API tiers; turn on "
+            "for richer canon cross-referencing on Tier 2+."
+        ),
+    )
     args = parser.parse_args()
 
     transcript_path = pathlib.Path(args.transcript)
@@ -224,7 +241,9 @@ def main() -> int:
         return 1
 
     snippet, usage = chronicle(
-        transcript_path.read_text(encoding="utf-8"), args.date
+        transcript_path.read_text(encoding="utf-8"),
+        args.date,
+        include_canons=args.with_canons,
     )
 
     print(

--- a/scripts/chronicle.py
+++ b/scripts/chronicle.py
@@ -41,7 +41,28 @@ EXAMPLE_SNIPPETS = [
     SNIPPETS_DIR / "snippet-2026-04-22-constitution-v1.1-publication.json",
 ]
 
-MODEL = "claude-opus-4-7"
+MODEL_CONFIGS: dict[str, dict] = {
+    # Strategic chronicles — full institutional depth, highest cost.
+    "opus": {
+        "model": "claude-opus-4-7",
+        "thinking": {"type": "adaptive"},
+        "output_config": {"effort": "high"},
+    },
+    # Routine chronicles — 3x cheaper, same adaptive thinking, ~95% quality.
+    "sonnet": {
+        "model": "claude-sonnet-4-6",
+        "thinking": {"type": "adaptive"},
+        "output_config": {"effort": "high"},
+    },
+    # Quick/mechanical chronicles — 5x cheaper than Opus. Haiku 4.5 rejects
+    # the `effort` parameter and doesn't support adaptive thinking; omit both.
+    "haiku": {
+        "model": "claude-haiku-4-5",
+        "thinking": {"type": "disabled"},
+    },
+}
+DEFAULT_MODEL = "opus"
+
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
 
@@ -146,14 +167,22 @@ def _extract_json(text: str) -> str:
 
 
 def chronicle(
-    transcript: str, date_str: str, *, include_canons: bool = False
-) -> tuple[dict, object]:
+    transcript: str,
+    date_str: str,
+    *,
+    include_canons: bool = False,
+    model_alias: str = DEFAULT_MODEL,
+) -> tuple[dict, object, str]:
+    if model_alias not in MODEL_CONFIGS:
+        raise ValueError(
+            f"unknown model alias {model_alias!r}; "
+            f"choose from {sorted(MODEL_CONFIGS)}"
+        )
+    config = MODEL_CONFIGS[model_alias]
+
     client = Anthropic()
     response = client.messages.create(
-        model=MODEL,
         max_tokens=16000,
-        thinking={"type": "adaptive"},
-        output_config={"effort": "high"},
         system=_build_system_prefix(include_canons=include_canons),
         messages=[
             {
@@ -168,6 +197,7 @@ def chronicle(
                 ),
             }
         ],
+        **config,
     )
 
     text = "".join(
@@ -187,7 +217,7 @@ def chronicle(
             + json.dumps(data, indent=2)[:500]
         )
 
-    return data, response.usage
+    return data, response.usage, config["model"]
 
 
 def _default_slug(snippet: dict) -> str:
@@ -233,6 +263,18 @@ def main() -> int:
             "for richer canon cross-referencing on Tier 2+."
         ),
     )
+    parser.add_argument(
+        "--model",
+        choices=sorted(MODEL_CONFIGS),
+        default=DEFAULT_MODEL,
+        help=(
+            "Which model tier to use. "
+            "opus = Claude Opus 4.7 (strategic, full depth, highest cost). "
+            "sonnet = Claude Sonnet 4.6 (~3x cheaper than opus, adaptive thinking). "
+            "haiku = Claude Haiku 4.5 (~5x cheaper, no thinking — use for "
+            "routine/mechanical chronicles). Default: opus."
+        ),
+    )
     args = parser.parse_args()
 
     transcript_path = pathlib.Path(args.transcript)
@@ -240,14 +282,15 @@ def main() -> int:
         print(f"error: transcript not found: {transcript_path}", file=sys.stderr)
         return 1
 
-    snippet, usage = chronicle(
+    snippet, usage, model_id = chronicle(
         transcript_path.read_text(encoding="utf-8"),
         args.date,
         include_canons=args.with_canons,
+        model_alias=args.model,
     )
 
     print(
-        "tokens: "
+        f"model: {model_id}  tokens: "
         f"input={usage.input_tokens} "
         f"cache_read={usage.cache_read_input_tokens} "
         f"cache_creation={usage.cache_creation_input_tokens} "

--- a/scripts/import-snippet.py
+++ b/scripts/import-snippet.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Apply an Aurelius snippet JSON directly to data/*.json.
+
+Closes the second half of the snippet pipeline. The chronicler (chronicle.py)
+turns transcripts into snippets; this script turns snippets into live data.
+The Codex app reads data/canons.json + data/volumes.json + data/journal.json
+on startup and syncs via the GitHub Contents API per Edict III.
+
+Operations supported (any combination per snippet, all optional):
+  - lore[]            -> data/canons.json .lore[]
+  - canon_drafts[]    -> data/canons.json .canons[]
+  - session           -> data/journal.json (matched by date)
+  - todos[]           -> data/volumes.json (per volume)
+  - chapter_updates[] -> data/volumes.json (per volume + chapter, patch-merged)
+
+Idempotent: existing IDs are skipped, never overwritten. Run --dry-run first
+to preview what would change.
+
+Usage:
+    python scripts/import-snippet.py docs/snippets/snippet-2026-04-22-foo.json
+    python scripts/import-snippet.py docs/snippets/snippet-*.json --dry-run
+    python scripts/import-snippet.py path/to/snippet.json --backup
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import glob
+import json
+import pathlib
+import shutil
+import sys
+from typing import Any
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+DATA_DIR = REPO_ROOT / "data"
+CANONS_PATH = DATA_DIR / "canons.json"
+VOLUMES_PATH = DATA_DIR / "volumes.json"
+JOURNAL_PATH = DATA_DIR / "journal.json"
+
+
+def _load(path: pathlib.Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write(path: pathlib.Path, data: dict) -> None:
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _ids(items: list[dict]) -> set[str]:
+    return {item["id"] for item in items if isinstance(item, dict) and "id" in item}
+
+
+def apply_lore(canons: dict, entries: list[dict]) -> tuple[list[str], list[str]]:
+    existing = _ids(canons.setdefault("lore", []))
+    added, skipped = [], []
+    for entry in entries:
+        if not isinstance(entry, dict) or "id" not in entry:
+            skipped.append(f"<malformed lore entry: {entry!r}>")
+            continue
+        if entry["id"] in existing:
+            skipped.append(entry["id"])
+            continue
+        canons["lore"].append(entry)
+        existing.add(entry["id"])
+        added.append(entry["id"])
+    return added, skipped
+
+
+def apply_canon_drafts(canons: dict, drafts: list[dict]) -> tuple[list[str], list[str]]:
+    existing = _ids(canons.setdefault("canons", []))
+    added, skipped = [], []
+    for draft in drafts:
+        if not isinstance(draft, dict) or "id" not in draft:
+            skipped.append(f"<malformed canon draft: {draft!r}>")
+            continue
+        if draft["id"] in existing:
+            skipped.append(draft["id"])
+            continue
+        canons["canons"].append(draft)
+        existing.add(draft["id"])
+        added.append(draft["id"])
+    return added, skipped
+
+
+def _strip_meta(d: dict) -> dict:
+    return {k: v for k, v in d.items() if not k.startswith("_")}
+
+
+def apply_session(journal: dict, session: dict) -> tuple[list[str], list[str]]:
+    if not isinstance(session, dict) or "id" not in session or "date" not in session:
+        return [], [f"<malformed session: missing id or date>"]
+
+    session = _strip_meta(session)
+    days = journal.setdefault("journal", [])
+
+    # Find existing day, or create
+    day = next((d for d in days if d.get("date") == session["date"]), None)
+    if day is None:
+        day = {"date": session["date"], "sessions": []}
+        days.append(day)
+        days.sort(key=lambda d: d.get("date", ""), reverse=True)
+
+    sessions = day.setdefault("sessions", [])
+    if any(s.get("id") == session["id"] for s in sessions):
+        return [], [session["id"]]
+    sessions.append(session)
+    return [session["id"]], []
+
+
+def apply_todos(volumes: dict, todo_ops: list[dict]) -> tuple[list[str], list[str]]:
+    vols = volumes.setdefault("volumes", [])
+    by_id = {v["id"]: v for v in vols if isinstance(v, dict)}
+    added, skipped = [], []
+    for op in todo_ops:
+        if not isinstance(op, dict):
+            skipped.append(f"<malformed todo op: {op!r}>")
+            continue
+        vol_id = op.get("volume")
+        todo = op.get("todo")
+        if not vol_id or not isinstance(todo, dict) or "id" not in todo:
+            skipped.append(f"<malformed todo op: {op!r}>")
+            continue
+        vol = by_id.get(vol_id)
+        if vol is None:
+            skipped.append(f"<unknown volume {vol_id} for todo {todo['id']}>")
+            continue
+        existing = _ids(vol.setdefault("todos", []))
+        if todo["id"] in existing:
+            skipped.append(todo["id"])
+            continue
+        vol["todos"].append(todo)
+        added.append(f"{vol_id}/{todo['id']}")
+    return added, skipped
+
+
+def _merge_patch(target: dict, patch: dict) -> None:
+    """Shallow merge: patch values overwrite target values key-by-key."""
+    for key, value in patch.items():
+        target[key] = value
+
+
+def apply_chapter_updates(
+    volumes: dict, updates: list[dict]
+) -> tuple[list[str], list[str]]:
+    vols = volumes.setdefault("volumes", [])
+    by_id = {v["id"]: v for v in vols if isinstance(v, dict)}
+    applied, skipped = [], []
+    for op in updates:
+        if not isinstance(op, dict):
+            skipped.append(f"<malformed chapter update: {op!r}>")
+            continue
+        vol_id = op.get("volume")
+        chapter_id = op.get("chapter")
+        patch = op.get("patch")
+        if not vol_id or not chapter_id or not isinstance(patch, dict):
+            skipped.append(f"<malformed chapter update: {op!r}>")
+            continue
+        vol = by_id.get(vol_id)
+        if vol is None:
+            skipped.append(f"<unknown volume {vol_id} for chapter {chapter_id}>")
+            continue
+        chapters = vol.setdefault("chapters", [])
+        chapter = next((c for c in chapters if c.get("id") == chapter_id), None)
+        if chapter is None:
+            skipped.append(f"<unknown chapter {vol_id}/{chapter_id}>")
+            continue
+        _merge_patch(chapter, patch)
+        applied.append(f"{vol_id}/{chapter_id}")
+    return applied, skipped
+
+
+def import_snippet(
+    snippet: dict,
+    canons: dict,
+    volumes: dict,
+    journal: dict,
+) -> dict[str, dict[str, list[str]]]:
+    if snippet.get("_snippet_version") != 1:
+        raise ValueError(
+            f"snippet missing _snippet_version: 1 (got {snippet.get('_snippet_version')!r})"
+        )
+
+    summary: dict[str, dict[str, list[str]]] = {}
+
+    if "lore" in snippet:
+        added, skipped = apply_lore(canons, snippet["lore"])
+        summary["lore"] = {"added": added, "skipped": skipped}
+
+    if "canon_drafts" in snippet:
+        added, skipped = apply_canon_drafts(canons, snippet["canon_drafts"])
+        summary["canons"] = {"added": added, "skipped": skipped}
+
+    if "session" in snippet:
+        added, skipped = apply_session(journal, snippet["session"])
+        summary["sessions"] = {"added": added, "skipped": skipped}
+
+    if "todos" in snippet:
+        added, skipped = apply_todos(volumes, snippet["todos"])
+        summary["todos"] = {"added": added, "skipped": skipped}
+
+    if "chapter_updates" in snippet:
+        added, skipped = apply_chapter_updates(volumes, snippet["chapter_updates"])
+        summary["chapter_updates"] = {"applied": added, "skipped": skipped}
+
+    return summary
+
+
+def _print_summary(snippet_path: pathlib.Path, summary: dict) -> None:
+    print(f"\n=== {snippet_path.name} ===")
+    if not summary:
+        print("  (no recognized operations in snippet)")
+        return
+    for kind, result in summary.items():
+        for action, ids in result.items():
+            if not ids:
+                continue
+            print(f"  {kind} {action}: {len(ids)}")
+            for ident in ids[:10]:
+                print(f"    - {ident}")
+            if len(ids) > 10:
+                print(f"    ... and {len(ids) - 10} more")
+
+
+def _backup(paths: list[pathlib.Path]) -> pathlib.Path:
+    stamp = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_dir = REPO_ROOT / ".import-backups" / stamp
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    for p in paths:
+        if p.exists():
+            shutil.copy2(p, backup_dir / p.name)
+    return backup_dir
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Apply Aurelius snippet JSON(s) to data/*.json."
+    )
+    parser.add_argument(
+        "snippets",
+        nargs="+",
+        help="One or more snippet JSON paths (globs OK).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would change without writing.",
+    )
+    parser.add_argument(
+        "--backup",
+        action="store_true",
+        help="Copy data/*.json to .import-backups/<stamp>/ before writing.",
+    )
+    args = parser.parse_args()
+
+    # Expand globs (PowerShell doesn't expand them for us)
+    snippet_paths: list[pathlib.Path] = []
+    for pattern in args.snippets:
+        matched = sorted(glob.glob(pattern))
+        if not matched:
+            if pathlib.Path(pattern).exists():
+                snippet_paths.append(pathlib.Path(pattern))
+            else:
+                print(f"error: no snippets match {pattern}", file=sys.stderr)
+                return 1
+        else:
+            snippet_paths.extend(pathlib.Path(p) for p in matched)
+
+    # Skip the _drafts/ subdirectory and any non-JSON
+    snippet_paths = [
+        p
+        for p in snippet_paths
+        if p.suffix == ".json" and "_drafts" not in p.parts
+    ]
+    if not snippet_paths:
+        print("error: no JSON snippets to import", file=sys.stderr)
+        return 1
+
+    canons = _load(CANONS_PATH)
+    volumes = _load(VOLUMES_PATH)
+    journal = _load(JOURNAL_PATH)
+
+    any_changes = False
+    for snippet_path in snippet_paths:
+        try:
+            snippet = _load(snippet_path)
+        except json.JSONDecodeError as exc:
+            print(f"error: {snippet_path}: invalid JSON: {exc}", file=sys.stderr)
+            return 1
+        try:
+            summary = import_snippet(snippet, canons, volumes, journal)
+        except ValueError as exc:
+            print(f"error: {snippet_path}: {exc}", file=sys.stderr)
+            return 1
+
+        _print_summary(snippet_path, summary)
+        if any(
+            v
+            for kind in summary.values()
+            for action, v in kind.items()
+            if action in ("added", "applied") and v
+        ):
+            any_changes = True
+
+    if not any_changes:
+        print("\nNo changes to write.")
+        return 0
+
+    if args.dry_run:
+        print("\n[dry-run] would write data/canons.json, data/volumes.json, data/journal.json")
+        return 0
+
+    if args.backup:
+        backup_dir = _backup([CANONS_PATH, VOLUMES_PATH, JOURNAL_PATH])
+        print(f"\nBacked up data files to {backup_dir.relative_to(REPO_ROOT)}")
+
+    _write(CANONS_PATH, canons)
+    _write(VOLUMES_PATH, volumes)
+    _write(JOURNAL_PATH, journal)
+    print("\nWrote data/canons.json, data/volumes.json, data/journal.json")
+    print("Next: commit + push, the app picks up changes via GitHub sync on next load.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

First Claude API automation in the Republic. `scripts/chronicle.py` reads a raw session transcript, sends it through Opus 4.7 (adaptive thinking, effort=high), and emits a valid Aurelius snippet JSON under `docs/snippets/`.

The Chronicler's single most manual step was drafting snippet JSON by hand at the end of every session — the `docs/snippets/` backlog is the evidence. This removes that step.

## What it does

- Loads `CLAUDE.md` + `data/canons.json` + two example snippets as a **cached system prefix** (`cache_control: ephemeral`) so repeated invocations pay the ~0.1× cache-read rate on the bulk of the context window
- Uses Opus 4.7 with `thinking: {type: "adaptive"}` and `output_config: {effort: "high"}`
- Validates that the output is a JSON object with `_snippet_version: 1` before writing
- Derives the output filename from the session summary (`snippet-YYYY-MM-DD-<slug>.json`), overridable via `--slug`
- Supports `--dry-run` to print to stdout instead of writing
- PEP 723 inline metadata (`anthropic>=0.92`) — `uv run scripts/chronicle.py ...` resolves deps on first run

## Usage

```bash
export ANTHROPIC_API_KEY=sk-ant-...
uv run scripts/chronicle.py path/to/transcript.txt
uv run scripts/chronicle.py transcript.txt --slug cabinet-convening --date 2026-04-22
uv run scripts/chronicle.py transcript.txt --dry-run
```

## Test plan

- [ ] `uv run scripts/chronicle.py --help` prints usage
- [ ] Run against a real session transcript with `--dry-run`; confirm output parses as JSON and validates `_snippet_version: 1`
- [ ] Run without `--dry-run`; confirm file written under `docs/snippets/` matches the naming convention
- [ ] Run twice in succession; confirm `cache_read_input_tokens` is non-zero on the second call (prompt caching working)
- [ ] Confirm the emitted snippet round-trips through the existing snippet import pipeline in the Codex app

## Notes

- This is Tier 1 #1 from the automation survey. Tier 1 #2 (Cipher-as-a-service PR review) is the natural next build — same SDK patterns in a GitHub Action wrapper
- Kept intentionally minimal: no retry logic, no streaming, no structured-output schema (the snippet shape is still evolving and over-constraining fought the model in prototyping). Validation is a single check on the top-level envelope

https://claude.ai/code/session_011uYZXqNuuGEKYmKxmZEhsK