### PR TITLE
Codex-side support for Temple of Mars: campaigns.json + Session v2 schema

### DIFF
--- a/data/campaigns.json
+++ b/data/campaigns.json
@@ -1,0 +1,132 @@
+{
+  "campaigns": [
+    {
+      "id": "war-time-2026-04-24",
+      "type": "war-time",
+      "status": "pending",
+      "title": "War Time: Scope Pivot + Velocity Event",
+      "started_at": "2026-04-24T02:30:00Z",
+      "ends_at": "2026-04-27T02:30:00Z",
+      "duration_hours": 72,
+      "trigger": "Book VI Article 2(c)+(d) — Scope Pivot + Velocity Event",
+      "provinces": ["sproutlab", "sep-dashboard", "sep-invoicing"],
+      "qa_lead": "cipher",
+      "recorders": ["aurelius"],
+      "phases": [
+        {
+          "id": "sproutlab-phase-1",
+          "campaign_id": "war-time-2026-04-24",
+          "province": "sproutlab",
+          "name": "Connection Indicator + Offline Badge",
+          "order": 1,
+          "hours": [0, 24],
+          "acceptance": "Connection indicator live, offline badge visible, merged to main",
+          "leads": ["lyra"],
+          "tasks": [
+            { "id": "sl-1-1", "phase_id": "sproutlab-phase-1", "name": "Assess sync visibility gaps", "status": "pending" },
+            { "id": "sl-1-2", "phase_id": "sproutlab-phase-1", "name": "Implement connection indicator", "status": "pending" },
+            { "id": "sl-1-3", "phase_id": "sproutlab-phase-1", "name": "Implement offline badge", "status": "pending" }
+          ]
+        },
+        {
+          "id": "sproutlab-phase-2",
+          "campaign_id": "war-time-2026-04-24",
+          "province": "sproutlab",
+          "name": "Cache Busting + Service Worker Version",
+          "order": 2,
+          "hours": [24, 48],
+          "acceptance": "Cache invalidation working, SW version bumped",
+          "leads": ["lyra"],
+          "tasks": [
+            { "id": "sl-2-1", "phase_id": "sproutlab-phase-2", "name": "Cache busting strategy", "status": "pending" },
+            { "id": "sl-2-2", "phase_id": "sproutlab-phase-2", "name": "SW version bump", "status": "pending" }
+          ]
+        },
+        {
+          "id": "sproutlab-phase-3",
+          "campaign_id": "war-time-2026-04-24",
+          "province": "sproutlab",
+          "name": "Auto-Refresh on Listener Fire",
+          "order": 3,
+          "hours": [48, 72],
+          "acceptance": "Auto-refresh implemented and tested, merged to main",
+          "leads": ["lyra"],
+          "tasks": [
+            { "id": "sl-3-1", "phase_id": "sproutlab-phase-3", "name": "Auto-refresh implementation", "status": "pending" },
+            { "id": "sl-3-2", "phase_id": "sproutlab-phase-3", "name": "Edge case testing", "status": "pending" }
+          ]
+        },
+        {
+          "id": "dashboard-phase-1",
+          "campaign_id": "war-time-2026-04-24",
+          "province": "sep-dashboard",
+          "name": "v2.1 Pragmatic Patch",
+          "order": 1,
+          "hours": [0, 2],
+          "acceptance": "Dashboard operational on v2.1 baseline",
+          "leads": ["nyx", "sovereign"],
+          "tasks": [
+            { "id": "dash-1-1", "phase_id": "dashboard-phase-1", "name": "Restore v2.1 baseline", "status": "complete", "notes": "Resolved pre-war via sep-dashboard PR #1" }
+          ]
+        },
+        {
+          "id": "dashboard-phase-2",
+          "campaign_id": "war-time-2026-04-24",
+          "province": "sep-dashboard",
+          "name": "Session 8 Spec Review",
+          "order": 2,
+          "hours": [2, 12],
+          "acceptance": "Session 8 spec locked and agreed",
+          "leads": ["nyx", "sovereign"],
+          "tasks": [
+            { "id": "dash-2-1", "phase_id": "dashboard-phase-2", "name": "Read Session 8 spec", "status": "pending" },
+            { "id": "dash-2-2", "phase_id": "dashboard-phase-2", "name": "Lock features", "status": "pending" }
+          ]
+        },
+        {
+          "id": "dashboard-phase-3",
+          "campaign_id": "war-time-2026-04-24",
+          "province": "sep-dashboard",
+          "name": "Session 8 Execution",
+          "order": 3,
+          "hours": [12, 72],
+          "acceptance": "Session 8 features merged to main",
+          "leads": ["nyx", "sovereign"],
+          "tasks": [
+            { "id": "dash-3-1", "phase_id": "dashboard-phase-3", "name": "Feature 1 design + impl", "status": "pending" },
+            { "id": "dash-3-2", "phase_id": "dashboard-phase-3", "name": "Feature 2 design + impl", "status": "pending" },
+            { "id": "dash-3-3", "phase_id": "dashboard-phase-3", "name": "QA & merge", "status": "pending" }
+          ]
+        },
+        {
+          "id": "invoicing-phase-1",
+          "campaign_id": "war-time-2026-04-24",
+          "province": "sep-invoicing",
+          "name": "UI Enhancements",
+          "order": 1,
+          "hours": [0, 48],
+          "acceptance": "UI enhancements merged to main, tested",
+          "leads": ["theron", "solara"],
+          "tasks": [
+            { "id": "inv-1-1", "phase_id": "invoicing-phase-1", "name": "Lock UI targets", "status": "pending" },
+            { "id": "inv-1-2", "phase_id": "invoicing-phase-1", "name": "Inputs, buttons, charts polish", "status": "pending" }
+          ]
+        },
+        {
+          "id": "invoicing-phase-2",
+          "campaign_id": "war-time-2026-04-24",
+          "province": "sep-invoicing",
+          "name": "Margin Dashboard (IL-4)",
+          "order": 2,
+          "hours": [48, 72],
+          "acceptance": "Margin Dashboard Phase IL-4 merged",
+          "leads": ["theron", "solara"],
+          "tasks": [
+            { "id": "inv-2-1", "phase_id": "invoicing-phase-2", "name": "Margin core features", "status": "pending" },
+            { "id": "inv-2-2", "phase_id": "invoicing-phase-2", "name": "Integration testing", "status": "pending" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/schema/SESSION_V2.md
+++ b/docs/schema/SESSION_V2.md
@@ -1,0 +1,89 @@
+# Session Schema v2 — Campaign Telemetry Extension
+
+**Status:** Draft (pending ratification)
+**Declared:** 2026-04-23 by Sovereign decree
+**Consumer:** Temple of Mars (Watchtower, sister to Command Center)
+**Mirror:** [`templeofmars/docs/SCHEMA.md`](https://github.com/Rishabh1804/TempleOfMars/blob/main/docs/SCHEMA.md)
+
+---
+
+## Why
+
+Temple of Mars observes campaign-level telemetry (sessions, tokens, cost, velocity) aggregated from Codex's session log. The existing Session schema in `journal.json` lacked campaign linkage and cost fields. This document declares the v2 extension.
+
+## Backwards compatibility
+
+**Non-breaking.** All new fields are optional. Existing sessions render unchanged. Temple degrades to zero-contribution aggregates for sessions missing campaign fields.
+
+## Extended Session (`journal.json`)
+
+```jsonc
+{
+  // EXISTING
+  "id": "session-2026-04-23-aurelius-01",
+  "summary": "Temple scaffold",
+  "volumes_touched": ["temple-of-mars"],
+  "decisions": ["Adopt Stack B (SvelteKit)"],
+  "bugs_found": 0,
+  "handoff": "Ignis takes builder seat Hour 0",
+
+  // NEW — campaign linkage
+  "campaign_id": "war-time-2026-04-24",
+  "phase_id": "sproutlab-phase-1",
+  "task_id": "sl-1-2",
+  "builder": "lyra",
+  "province": "sproutlab",
+
+  // NEW — wall-clock
+  "started_at": "2026-04-24T02:30:00Z",
+  "ended_at": "2026-04-24T04:15:00Z",
+
+  // NEW — tokens + model (for cost derivation)
+  "model": "opus-4-7",
+  "tokens_in": 125000,
+  "tokens_out": 18500,
+
+  // NEW — git outputs (auto-derivable)
+  "commits": ["abc1234", "def5678"],
+  "loc_delta": 234,
+
+  // NEW — lore trail
+  "lore_generated": ["lore-xyz"]
+}
+```
+
+## Enums
+
+- `builder`: lyra | nyx | sovereign | theron | solara | cipher | aurelius | orinth | ignis | rune | maren | kael
+- `province`: sproutlab | sep-dashboard | sep-invoicing | codex | command-center
+- `model`: opus-4-7 | opus-4-6 | sonnet-4-6 | haiku-4-5 | other
+
+## `session_log` snippet type
+
+New snippet type in the import pipeline. Full operation catalog in the Temple schema mirror.
+
+- `record_session` — writes a complete session record; dedupes by `id`.
+- `update_task_status` — advances a task's status in `campaigns.json`. Accepts: pending | in-progress | review | complete | blocked.
+- `log_blocker` — optional Priority 3 capture for post-war Cautionary Tale synthesis. Attaches to a session.
+
+## Pricing table
+
+USD per 1M tokens. Reconcile quarterly against Anthropic public rates.
+
+| Model | Input | Output |
+|---|---|---|
+| opus-4-7 | 15 | 75 |
+| opus-4-6 | 15 | 75 |
+| sonnet-4-6 | 3 | 15 |
+| haiku-4-5 | 1 | 5 |
+
+## Ratification path
+
+1. Schema mirror in Temple repo (shipped alongside this doc)
+2. `session_log` snippet handler implementation in Codex import pipeline (next PR)
+3. First War Time session logs → validates end-to-end
+4. Canon entry promoting v2 to stable schema (post-War, after validation)
+
+---
+
+*Codex is the territory. Temple is the map. This schema is the contract between them.*


### PR DESCRIPTION
## Summary

Two Codex-side additions to support Temple of Mars v0.1:

1. **`data/campaigns.json`** — new authoritative file. Defines the War Time 2026-04-24 campaign with 8 phases across 3 provinces, 17 tasks, leads + acceptance criteria per phase. Temple reads this live via `raw.githubusercontent.com` and falls back to an internal seed when unavailable.
2. **`docs/schema/SESSION_V2.md`** — draft extension to the Session schema in `journal.json`, adding campaign-linkage + telemetry fields (campaign_id, phase_id, builder, province, started_at, ended_at, model, tokens_in/out, commits[], loc_delta, lore_generated[]). All new fields optional; existing sessions render unchanged.

Also introduces the `session_log` snippet type in the import pipeline (three ops: `record_session`, `update_task_status`, `log_blocker`) as the capture mechanism for campaign telemetry.

## Why

War Time 2026-04-24 begins at dawn tomorrow. The Sovereign commissioned Temple of Mars as a sister Monument to the Command Center — a read-only Watchtower that aggregates telemetry across every active province. Temple's data contract needs to land on Codex before it can go live.

## Metrics captured

Priority 1 + 2 per Sovereign decree:
- Sessions per task / phase / province / campaign
- Tokens in + out per session; aggregated per phase/campaign
- Model used (opus-4-7 / opus-4-6 / sonnet-4-6 / haiku-4-5) — drives $ cost derivation
- Wall-clock duration per session
- Commits per session (auto-derived from `commits[]`)
- LOC delta per session
- Token efficiency ratio (out/in)

## Non-breaking

- `campaigns.json` is a new file; nothing pre-existing touched
- Session schema v2 extensions are all optional additions
- Existing sessions continue to load + render normally
- Snippet import pipeline gains a new type; existing types untouched

## Paired PR

- **Temple side:** [Rishabh1804/TempleOfMars#paired](https://github.com/Rishabh1804/TempleOfMars/pulls) — scaffold + dashboard + Codex fetchers ready to consume these files

## Follow-ups

- [ ] `session_log` snippet handler implementation in Codex import pipeline (next PR — schema is drafted, handler is not yet wired)
- [ ] Canon entry promoting Session v2 to stable (post-war, after validation)
- [ ] Ignis Builder-seat canon entry (`canon-inst-*` class) — Minister seat vacated per Sovereign decree 2026-04-23

## Test plan

- [ ] `campaigns.json` is valid JSON and parses cleanly
- [ ] Temple loads it via `raw.githubusercontent.com/rishabh1804/Codex/main/data/campaigns.json` and renders War Time dashboard with `source: 'codex'` (not `'seed'`)
- [ ] Session schema v2 doc renders correctly in GitHub
- [ ] First War Time `session_log` snippet import successfully writes a telemetry-enriched session record into `journal.json` (requires paired handler PR)

---

_Generated by [Claude Code](https://claude.ai/code/session_hello-aurelius-IeMEX)_