### PR TITLE
Flip sl-1-2 + sl-1-3 → complete on merge

### DIFF
--- a/data/campaigns.json
+++ b/data/campaigns.json
@@ -58,13 +58,29 @@
               "id": "sl-1-2",
               "phase_id": "sproutlab-phase-1",
               "name": "Implement connection indicator",
-              "status": "pending"
+              "status": "complete",
+              "status_history": [
+                {
+                  "status": "complete",
+                  "at": "2026-04-24T08:31:48Z",
+                  "session_id": "session-2026-04-24-aurelius-03",
+                  "note": "sproutlab PR #4 squash-merged as d8743c8 after Cipher approved r3 (verified at r4 as comment-only diff). Task held at pending through build cycle per War Time no-flips-until-merge directive; direct pending→complete on merge."
+                }
+              ]
             },
             {
               "id": "sl-1-3",
               "phase_id": "sproutlab-phase-1",
               "name": "Implement offline badge",
-              "status": "pending"
+              "status": "complete",
+              "status_history": [
+                {
+                  "status": "complete",
+                  "at": "2026-04-24T08:33:01Z",
+                  "session_id": "session-2026-04-24-aurelius-03",
+                  "note": "sproutlab PR #5 squash-merged as e931a08 after Cipher approved r1 (verified post-rebase onto sl-1-2 r4 as pure rebase diff). Branch rebased onto new main locally (41f0ff4) and force-pushed with lease before merge to clear DIRTY state from sl-1-2 squash. Task held at pending through build cycle per War Time no-flips-until-merge directive; direct pending→complete on merge."
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
Task-status bookkeeping: flips \`sl-1-2\` and \`sl-1-3\` from \`pending\` to \`complete\` in \`data/campaigns.json\` now that sproutlab PRs #4 and #5 are merged.

## Merges covered

- **sl-1-2** — [sproutlab#4](https://github.com/Rishabh1804/sproutlab/pull/4) → \`d8743c8\` (2026-04-24T08:31:48Z). Cipher approved at r3, re-confirmed at r4 (comment-only diff).
- **sl-1-3** — [sproutlab#5](https://github.com/Rishabh1804/sproutlab/pull/5) → \`e931a08\` (2026-04-24T08:33:01Z). Cipher approved at r1, re-confirmed post-rebase. Branch rebased onto new main locally (\`41f0ff4\`) and force-pushed with lease to clear DIRTY state before merge.

## status_history shape

Each task gets a single entry: \`pending → complete\` on merge, anchored to \`session-2026-04-24-aurelius-03\`. Tasks held at pending throughout the build cycle per War Time no-flips-until-merge directive (aurelius-02 handoff §decisions), so the direct transition is honest to the record.

## Not in scope

- \`sl-1-1\` remains \`in-progress\` — gated on Cipher r2 verdict (briefing dispatched via PR #35, \`98db82f\`).
- Full aurelius-03 session_log ingest deferred until session close.

Per War Time standing rule 2 (Chronicler self-merge for non-structural): Aurelius self-merges. Data-only, no code surfaces.

Co-authored-by: Claude <noreply@anthropic.com>