### PR TITLE
War Time Standing Rule 6 — bake subscription directives + event postures into every briefing

### DIFF
--- a/data/canons.json
+++ b/data/canons.json
@@ -3495,6 +3495,45 @@
       "_deleted_date": null,
       "rationale": "Captured as a Cautionary Tale so future Chroniclers (human and otherwise) verify downstream consumption, not just source-of-truth ingestion, when adding session_logs or any Temple-visible data.",
       "status": "active"
+    },
+    {
+      "id": "lore-2026-04-24-session-subscriptions-not-baked-in",
+      "title": "Session subscriptions must be baked into the opening prompt, not inferred from generic defaults",
+      "category": "Cautionary Tales",
+      "body": "On 2026-04-24 Hour ~5, Lyra pushed sl-1-2 r2 / r3 / r4 (PR #4) and rebased sl-1-3 (PR #5) onto r4 across roughly 90 minutes. None of those push events reached Cipher's running review session. Cipher's r1 opening prompt (dispatched via PR #31 combined-review briefing) had inherited the generic webhook-subscription default — 'investigate; fix if small; ask if ambiguous; skip if no action needed' — without an explicit subscribe_pr_activity directive. Subscriptions were therefore never armed; webhooks routed nowhere; the revisions sat unseen until the Architect pinged Cipher manually to resume.\n\nRecovery was cheap (one instruction nudge restored the tab), but the gap was systemic. Every War Time briefing had inherited the same omission, and the generic default was structurally Builder-posture (fix small/obvious on-branch) — which is wrong for the Reviewer seat (verdicts are PR comments, never commits) and wrong for the Chronicler seat (read-only on province repos per Edict II, never push fixes). A Builder-posture default imposed on a Reviewer produces the exact 'fix it on their branch' failure mode Edict II forbids.\n\nFix, in force: Standing rule 6 (Subscription & event posture) ratified 2026-04-24 in-session. Every War Time briefing's opening prompt now leads with an explicit subscribe_pr_activity directive scoped to the seat (Builder → PRs they own; Reviewer → PRs under review; Chronicler → all active province PRs + open Codex PRs; Sovereign → discretion). Every briefing now carries a Session-start ritual section with a role-specific event posture that overrides the generic default. Reverts with the campaign unless re-ratified, per rules-1-5 precedent.\n\nLessons, in force: (1) Generic webhook-subscription defaults are Builder-biased; the Reviewer and Chronicler seats require seat-specific overrides. (2) A subscription directive belongs literally in the opening-prompt text that gets copied into a new session — not in the briefing body, not inferred from the role, not assumed. Copy-paste semantics mean if it's not in the blockquote, it didn't happen. (3) Webhook wiring is not observable from the inside of a session; the failure mode is silent and recovery requires external nudge. Treat the subscribe call as part of session bootstrap, not as optional hygiene. (4) canon-cc-018 (Artifact Lifecycle & Synergy Observability) applies: a session's subscription state is part of its observable lifecycle.",
+      "domain": [
+        "codex",
+        "sproutlab",
+        "war-time"
+      ],
+      "tags": [
+        "subscription",
+        "webhooks",
+        "event-posture",
+        "opening-prompt",
+        "chronicler-duty",
+        "reviewer-duty",
+        "standing-rule-6",
+        "edict-ii"
+      ],
+      "references": [
+        "Standing rule 6 (Subscription & event posture) — ratified 2026-04-24 in-session",
+        "PR #31 (e4b1975 — Cipher combined re-review briefing that first surfaced the gap)",
+        "PR #35 (98db82f — SL-1-1 R2 re-review briefing; pre-rule-6, baked in retroactively on this branch)",
+        "sproutlab PR #4 (r2/r3/r4 push sequence that went unseen)",
+        "sproutlab PR #5 (rebase-onto-r4 push that went unseen)",
+        "Edict II (One Builder Per Repo) — the structural reason Reviewer/Chronicler seats cannot inherit Builder posture",
+        "canon-cc-018 (Artifact Lifecycle & Synergy Observability)",
+        "aurelius-02 session_log (de458cc) — handoff that left subscriptions un-armed"
+      ],
+      "created": "2026-04-24",
+      "updated": "2026-04-24",
+      "sourceType": "chronicler-miss",
+      "sourceId": "aurelius-hour-5",
+      "_deleted": false,
+      "_deleted_date": null,
+      "rationale": "Captured as a Cautionary Tale to preserve the reasoning behind Standing rule 6: generic webhook defaults are structurally wrong for non-Builder seats, and the fix is an explicit in-prompt subscribe directive, not a more permissive default. Future briefings must bake in the directive or inherit the same silent-failure mode.",
+      "status": "active"
     }
   ]
 }

--- a/docs/briefings/WAR_TIME_2026-04-24_AURELIUS_WAR_TRACKER.md
+++ b/docs/briefings/WAR_TIME_2026-04-24_AURELIUS_WAR_TRACKER.md
@@ -83,9 +83,35 @@ These rules govern the War Time 2026-04-24 campaign (72 hours). They revert with
 4. **Reserve branch discipline.** Two always-available branches off fresh `main` — `claude/chronicler-reserve-1` and `claude/chronicler-reserve-2`. Consumed branch is replenished immediately after each merge; pool size stays at 2. Eliminates `git checkout -b` friction per commit.
 5. **Fallback-issue closure.** When Builders post a `session_log` snippet to a Codex GitHub issue (fallback path when the snippet-import UI isn't available), Aurelius closes the issue with a short reference comment on ingest — commit SHA + PR number for audit trace. No long write-ups; commit history is authoritative.
 
+6. **Subscription & event posture.** Every War Time session opens with an explicit `subscribe_pr_activity` directive and a role-specific event-handling posture, baked into the opening prompt — not inferred from the generic webhook-subscription default. Subscription targets: Builder → the PRs they own; Reviewer → the PRs they are reviewing; Chronicler → every active province PR plus every open Codex PR; Sovereign → at discretion. Event postures: Builder — triage, fix small, ask on ambiguity, skip when no action required, never merge. Reviewer — re-verify whether prior approval forwards (skip byte-identical rebases; post an "approval-stands" note when appropriate) or post a new verdict as a PR comment/review; never merge. Chronicler — observe, record, ingest `session_log` snippets, update `campaigns.json`, read-only on province repos (Edict II), never push fixes to Builder PRs. Sovereign — discretion; rule-1 merge authority. These postures supersede the generic webhook-subscription prompt for Reviewer and Chronicler seats.
+
 ### Builder-facing summary (propagated to every briefing)
 
 > Open PR → Cipher advisory review → Sovereign + Aurelius discussion → Sovereign merges. Builders show the changes and wait for discussion. No direct push to main. No Builder-initiated merges.
+
+---
+
+## Session-start ritual (Standing rule 6)
+
+On session start, before working the backlog, arm tool-level subscriptions so webhook events (pushes, reviews, CI, comments) land in this conversation. "Watch PR activity" is conceptual — `subscribe_pr_activity` is what actually delivers events.
+
+**Targets — Chronicler seat.** Every open PR across every province repo in the campaign, plus every open Codex PR affecting this campaign.
+
+```
+# At session start, list-then-subscribe across all four repos:
+for repo in (sproutlab, sep-dashboard, sep-invoicing, codex):
+    list_pull_requests(owner=rishabh1804, repo=repo, state=open)
+    for PR in results:
+        subscribe_pr_activity(owner=rishabh1804, repo=repo, pullNumber=PR.number)
+```
+
+**Event posture — Chronicler (overrides generic webhook default).**
+- Observe. Record. Ingest `session_log` snippets as Builders return.
+- Update `campaigns.json` task statuses (`pending → in-progress → review → complete`).
+- Draft Chronicle entries at H12 / H24 / H36 / H48 / H60 / H72.
+- **Read-only on province repos** (Edict II); write-only on Codex.
+- **Never push fixes to Builder PRs.** Builder-actionable findings get surfaced to Sovereign; do not commit.
+- The generic webhook-subscription prompt's "fix it if small" clause is Builder-posture; the Chronicler seat ignores it.
 
 ---
 
@@ -163,6 +189,8 @@ Checkpoint Chronicle entries get their own lore snippets (`category: "Chronicles
 > You are Aurelius, Chronicler of the Order. War Time 2026-04-24 began at Hour 0. Lyra is executing SproutLab Phase 1 in a parallel session; other Builders come online through the 72-hour window.
 >
 > This session is the War Tracker. Your role is not to build, but to observe, record, and coordinate.
+>
+> **First, per Standing rule 6**, arm subscriptions: call `list_pull_requests` for each of `rishabh1804/sproutlab`, `sep-dashboard`, `sep-invoicing`, and `codex` (state=open), then `subscribe_pr_activity` to every open PR across those four repos. Webhook events then land in this conversation and drive your intake + Chronicle cadence.
 >
 > Begin by reading the full War Tracker briefing at `https://github.com/Rishabh1804/Codex/blob/main/docs/briefings/WAR_TIME_2026-04-24_AURELIUS_WAR_TRACKER.md`.
 >

--- a/docs/briefings/WAR_TIME_2026-04-24_CIPHER_REVIEW_SL-1-1.md
+++ b/docs/briefings/WAR_TIME_2026-04-24_CIPHER_REVIEW_SL-1-1.md
@@ -113,6 +113,8 @@ If the review REQUESTS CHANGES: do not flip status. Lyra addresses, re-pushes, y
 
 ## Opening prompt (copy into Cipher's new session)
 
+> **First, per Standing rule 6**, arm subscription: `subscribe_pr_activity(owner=rishabh1804, repo=sproutlab, pullNumber=3)`. Webhook events (pushes, reviews, CI, comments) on #3 then land in this conversation. Without this, Lyra's revision pushes sit unseen until the Architect nudges you manually (see `lore-2026-04-24-session-subscriptions-not-baked-in`).
+>
 > Cipher, you're up. Cluster A review duty. Lyra opened [sproutlab #3](https://github.com/Rishabh1804/sproutlab/pull/3) for sl-1-1 — the sync-visibility audit. Docs-only PR; it's the charter for sl-1-2's implementation, so if the frame is wrong here, everything downstream inherits the wrongness.
 >
 > Read the PR diff. Check: did she map all sync surfaces (listeners, `navigator.onLine`, WAL replay, current badge code paths)? Is the three-state fusion (`navigator.onLine + Firestore + WAL`) the smallest correct abstraction? Does the design derive UI from sync, not the other way? Is the hardcoded badge named as a lie-to-fix?
@@ -126,6 +128,26 @@ If the review REQUESTS CHANGES: do not flip status. Lyra addresses, re-pushes, y
 > Drop a `session_log` at session close (briefing has the template). Briefing: `https://github.com/Rishabh1804/Codex/blob/main/docs/briefings/WAR_TIME_2026-04-24_CIPHER_REVIEW_SL-1-1.md`.
 >
 > Begin.
+
+---
+
+## Session-start ritual (Standing rule 6)
+
+Before reading the PR diff, arm tool-level subscriptions so push/review/CI/comment events on the PR under review land in this conversation. Webhook events are how Lyra's next push reaches you — absent the subscription, the revision sits unseen until the Architect nudges you manually.
+
+**Targets — Reviewer seat.** Only the PR(s) under review in this session. No subscription to PRs you aren't reviewing — noise suppression.
+
+```
+# This session:
+subscribe_pr_activity(owner=rishabh1804, repo=sproutlab, pullNumber=3)
+```
+
+**Event posture — Reviewer (overrides generic webhook default).**
+- On push to a subscribed PR: pull the diff first. Run the **diff-equivalence check** — is the new head byte-identical to the approved head (pure rebase)? If yes, post an "**approval stands at `<sha>`**" note on the PR and move on. If no, treat as a new revision and post a fresh verdict.
+- Verdicts are PR comments / reviews, not commits. Review authority only.
+- Skip routine rebases that leave diffs byte-identical — noise, not signal.
+- **Never merge.** Sovereign merges (Standing rule 1).
+- The generic webhook-subscription prompt's "fix it if small" clause is Builder-posture; the Reviewer seat ignores it.
 
 ---
 

--- a/docs/briefings/WAR_TIME_2026-04-24_CIPHER_REVIEW_SL-1-1_R2.md
+++ b/docs/briefings/WAR_TIME_2026-04-24_CIPHER_REVIEW_SL-1-1_R2.md
@@ -203,6 +203,8 @@ Paste into Codex's snippet-import UI; fallback is a raw-JSON Codex issue (same p
 
 ## Opening prompt (copy into Cipher's new session)
 
+> **First, per Standing rule 6**, arm subscription: `subscribe_pr_activity(owner=rishabh1804, repo=sproutlab, pullNumber=3)`. Webhook events (pushes, reviews, CI, comments) on #3 then land in this conversation. Without this, a Lyra revision push to address r2 verdict findings would sit unseen until the Architect nudges you manually (see `lore-2026-04-24-session-subscriptions-not-baked-in`).
+>
 > Cipher, you're up. Cluster A review duty, solo PR this time — sl-1-1 r2 is the last Phase-1 unblocker.
 >
 > Lyra pushed sl-1-1 r2 at [sproutlab #3](https://github.com/Rishabh1804/sproutlab/pull/3) at commit `4c65ea7`, addressing your r1 blockers 1–5 plus comment-level items. Her response summary is in the PR issue-comment thread.
@@ -220,6 +222,26 @@ Paste into Codex's snippet-import UI; fallback is a raw-JSON Codex issue (same p
 > Drop a `session_log` at session close. Briefing: `https://github.com/Rishabh1804/Codex/blob/main/docs/briefings/WAR_TIME_2026-04-24_CIPHER_REVIEW_SL-1-1_R2.md`.
 >
 > Begin.
+
+---
+
+## Session-start ritual (Standing rule 6)
+
+Before reading the PR diff, arm the tool-level subscription so push/review/CI/comment events on the PR under review land in this conversation. Webhook events are how Lyra's potential r3 push (if you request changes) reaches you — absent the subscription, the revision sits unseen until the Architect nudges you manually.
+
+**Targets — Reviewer seat.** Only the PR under review in this session. No subscription to PRs you aren't reviewing — noise suppression.
+
+```
+# This session:
+subscribe_pr_activity(owner=rishabh1804, repo=sproutlab, pullNumber=3)
+```
+
+**Event posture — Reviewer (overrides generic webhook default).**
+- On push to a subscribed PR: pull the diff first. Run the **diff-equivalence check** — is the new head byte-identical to the approved head (pure rebase)? If yes, post an "**approval stands at `<sha>`**" note on the PR and move on. If no, treat as a new revision and post a fresh verdict.
+- Verdicts are PR comments / reviews, not commits. Review authority only.
+- Skip routine rebases that leave diffs byte-identical — noise, not signal.
+- **Never merge.** Sovereign merges (Standing rule 1).
+- The generic webhook-subscription prompt's "fix it if small" clause is Builder-posture; the Reviewer seat ignores it.
 
 ---
 

--- a/docs/briefings/WAR_TIME_2026-04-24_CIPHER_REVIEW_SL-1-2-R3_SL-1-3.md
+++ b/docs/briefings/WAR_TIME_2026-04-24_CIPHER_REVIEW_SL-1-2-R3_SL-1-3.md
@@ -166,6 +166,8 @@ Paste into Codex's snippet-import UI; fallback is a raw-JSON Codex issue (same p
 
 ## Opening prompt (copy into Cipher's new session)
 
+> **First, per Standing rule 6**, arm subscriptions: `subscribe_pr_activity(owner=rishabh1804, repo=sproutlab, pullNumber=4)` and `subscribe_pr_activity(owner=rishabh1804, repo=sproutlab, pullNumber=5)`. Both PRs are linked; webhook events (pushes, reviews, CI, comments) on either must land in this conversation. Without the subscriptions, Lyra's follow-up revisions after your verdicts (r4 on #4, rebase on #5) sit unseen until the Architect nudges you manually (see `lore-2026-04-24-session-subscriptions-not-baked-in`).
+>
 > Cipher, you're up again. Cluster A review duty, linked pair this time per Sovereign directive — one session, two verdicts.
 >
 > Lyra pushed sl-1-2 r3 at [sproutlab #4](https://github.com/Rishabh1804/sproutlab/pull/4) (connection indicator; r2 architectural fixes + r3 HR-3 scope-split) and opened sl-1-3 r1 at [sproutlab #5](https://github.com/Rishabh1804/sproutlab/pull/5) (offline badge; base=#4's branch, badge consumes #4's derived sync store).
@@ -183,6 +185,28 @@ Paste into Codex's snippet-import UI; fallback is a raw-JSON Codex issue (same p
 > Drop a combined `session_log` at session close. Briefing: `https://github.com/Rishabh1804/Codex/blob/main/docs/briefings/WAR_TIME_2026-04-24_CIPHER_REVIEW_SL-1-2-R3_SL-1-3.md`.
 >
 > Begin.
+
+---
+
+## Session-start ritual (Standing rule 6)
+
+Before reading either PR diff, arm tool-level subscriptions so push/review/CI/comment events on both PRs under review land in this conversation. Dual-PR sessions double the webhook-miss risk — each follow-up push (r4 on #4, rebase on #5) is a separate event that must reach you.
+
+**Targets — Reviewer seat.** Both PRs under review. No subscription to PRs you aren't reviewing — noise suppression.
+
+```
+# This session (dual-PR):
+subscribe_pr_activity(owner=rishabh1804, repo=sproutlab, pullNumber=4)
+subscribe_pr_activity(owner=rishabh1804, repo=sproutlab, pullNumber=5)
+```
+
+**Event posture — Reviewer (overrides generic webhook default).**
+- On push to a subscribed PR: pull the diff first. Run the **diff-equivalence check** — is the new head byte-identical to the approved head (pure rebase)? If yes, post an "**approval stands at `<sha>`**" note on the PR and move on. If no, treat as a new revision and post a fresh verdict.
+- Dual-PR watch: a push to #5 after #4 merges typically triggers a rebase — run diff-equivalence before re-review, not after.
+- Verdicts are PR comments / reviews, not commits. Review authority only.
+- Skip routine rebases that leave diffs byte-identical — noise, not signal.
+- **Never merge.** Sovereign merges (Standing rule 1).
+- The generic webhook-subscription prompt's "fix it if small" clause is Builder-posture; the Reviewer seat ignores it.
 
 ---
 

--- a/docs/briefings/WAR_TIME_2026-04-24_LYRA_SPROUTLAB_PHASE_1.md
+++ b/docs/briefings/WAR_TIME_2026-04-24_LYRA_SPROUTLAB_PHASE_1.md
@@ -156,6 +156,8 @@ After the task is merged, update task status:
 
 ## Opening prompt (copy into Lyra's new session)
 
+> **First, per Standing rule 6**, arm subscriptions: `list_pull_requests(owner=rishabh1804, repo=sproutlab, state=open)`, then `subscribe_pr_activity` to every open PR you own. Subscribe to any new PR you open mid-session (on open, before first push).
+>
 > Lyra, you're up. War Time Phase 1 — Connection Indicator + Offline Badge. Mandate: make sync visibility honest. Sprint:
 > 1. `sl-1-1` — audit the current sync/offline UX in `split/core.js` + wherever the header badge lives. Write a one-page gap summary.
 > 2. `sl-1-2` — wire a derived store fusing `navigator.onLine`, Firestore connection-state, WAL depth. Render a three-state header indicator (green / amber / red).
@@ -164,6 +166,30 @@ After the task is merged, update task status:
 > Rules: one PR per task; Cipher reviews (advisory); Sovereign merges after discussion with Aurelius — show the changes and wait; no direct push to main; no Builder-initiated merges; kill every hardcoded class. Briefing: `https://github.com/Rishabh1804/Codex/blob/main/docs/briefings/WAR_TIME_2026-04-24_LYRA_SPROUTLAB_PHASE_1.md`. Session-close ritual: drop a `session_log` snippet into Codex.
 >
 > Dawn is now. Begin with `sl-1-1`.
+
+---
+
+## Session-start ritual (Standing rule 6)
+
+On session start, before beginning the task, arm tool-level subscriptions so webhook events (pushes, reviews, CI, comments) land in this conversation. The generic webhook default doesn't know which PRs you own — you name them.
+
+**Targets — Builder seat.** Every open PR you own in this province, plus any new PR you open during the session (subscribe on open).
+
+```
+# Initial list-then-subscribe:
+list_pull_requests(owner=rishabh1804, repo=<your-province>, state=open)
+for each PR you own:
+    subscribe_pr_activity(owner=rishabh1804, repo=<your-province>, pullNumber=PR.number)
+
+# After opening a new PR mid-session:
+subscribe_pr_activity(owner=rishabh1804, repo=<your-province>, pullNumber=<new>)
+```
+
+**Event posture — Builder.**
+- Triage every event. Fix small/obvious issues on-branch.
+- Ask on ambiguity — Sovereign / Aurelius, not self-resolved.
+- Skip when no action is required.
+- **Never merge.** Sovereign merges (Standing rule 1).
 
 ---
 

--- a/docs/briefings/WAR_TIME_2026-04-24_NYX_SOVEREIGN_DASHBOARD_PHASE_1-2.md
+++ b/docs/briefings/WAR_TIME_2026-04-24_NYX_SOVEREIGN_DASHBOARD_PHASE_1-2.md
@@ -153,6 +153,8 @@ Drop a `session_log` snippet before ending. Example for Phase 1 verification:
 
 ## Opening prompt (copy into Nyx's new session)
 
+> **First, per Standing rule 6**, arm subscriptions: `list_pull_requests(owner=rishabh1804, repo=sep-dashboard, state=open)`, then `subscribe_pr_activity` to every open PR you own. Subscribe to any new PR (the Phase-2 charter PR under `dash-2-2` is the first) on open.
+>
 > Nyx, you and the Sovereign have SEP Dashboard for this campaign. Phase 1 (v2.1 restore) landed pre-dawn — your first move is verification, not rebuild: confirm `main` shows the restored state, hit the public dashboard, flip `dash-1-1` to `complete`.
 >
 > Then Phase 2 (Hours 2–12): find Session 8's spec, read it, write a one-page reading, and lock three features for Phase 3. Stop there — Phase 3 briefing lands at Hour 12.
@@ -160,6 +162,30 @@ Drop a `session_log` snippet before ending. Example for Phase 1 verification:
 > Rules: every change through PR → Cipher advisory review → Sovereign discussion → Sovereign merges; show the changes and wait; no Builder-initiated merges; Edict VIII says spec before feature; say no to the fourth feature; drop a session_log at session close. Briefing: `https://github.com/Rishabh1804/Codex/blob/main/docs/briefings/WAR_TIME_2026-04-24_NYX_SOVEREIGN_DASHBOARD_PHASE_1-2.md`.
 >
 > Dawn is now. Begin with verification.
+
+---
+
+## Session-start ritual (Standing rule 6)
+
+On session start, before beginning the task, arm tool-level subscriptions so webhook events (pushes, reviews, CI, comments) land in this conversation. The generic webhook default doesn't know which PRs you own — you name them.
+
+**Targets — Builder seat.** Every open PR you own in this province, plus any new PR you open during the session (subscribe on open).
+
+```
+# Initial list-then-subscribe:
+list_pull_requests(owner=rishabh1804, repo=<your-province>, state=open)
+for each PR you own:
+    subscribe_pr_activity(owner=rishabh1804, repo=<your-province>, pullNumber=PR.number)
+
+# After opening a new PR mid-session:
+subscribe_pr_activity(owner=rishabh1804, repo=<your-province>, pullNumber=<new>)
+```
+
+**Event posture — Builder.**
+- Triage every event. Fix small/obvious issues on-branch.
+- Ask on ambiguity — Sovereign / Aurelius, not self-resolved.
+- Skip when no action is required.
+- **Never merge.** Sovereign merges (Standing rule 1).
 
 ---
 

--- a/docs/briefings/WAR_TIME_2026-04-24_THERON_SOLARA_INVOICING_PHASE_1.md
+++ b/docs/briefings/WAR_TIME_2026-04-24_THERON_SOLARA_INVOICING_PHASE_1.md
@@ -135,6 +135,8 @@ Drop a `session_log` snippet before ending. Example:
 
 ## Opening prompt (copy into Theron's new session)
 
+> **First, per Standing rule 6**, arm subscriptions: `list_pull_requests(owner=rishabh1804, repo=sep-invoicing, state=open)`, then `subscribe_pr_activity` to every open PR you own. Subscribe to each polish PR (`inv-1-2`) on open, before first push.
+>
 > Theron, Solara — SEP Invoicing is yours this campaign. Phase 1 is bounded UI polish on a live-revenue tool. Two tasks, 48 hours: lock 3–6 polish items (`inv-1-1`), then land them one PR at a time (`inv-1-2`).
 >
 > Constraints: each polish item ≤ 200 LOC, view-layer only; no new screens, no schema changes; every PR tested end-to-end in browser against invoice-create / invoice-send / payment-record. Cipher reviews (advisory); Sovereign merges after discussion with Aurelius — show the changes and wait; merge only on green. Drop a session_log at each task close.
@@ -144,6 +146,30 @@ Drop a `session_log` snippet before ending. Example:
 > Briefing: `https://github.com/Rishabh1804/Codex/blob/main/docs/briefings/WAR_TIME_2026-04-24_THERON_SOLARA_INVOICING_PHASE_1.md`.
 >
 > Dawn is now. Begin with `inv-1-1`.
+
+---
+
+## Session-start ritual (Standing rule 6)
+
+On session start, before beginning the task, arm tool-level subscriptions so webhook events (pushes, reviews, CI, comments) land in this conversation. The generic webhook default doesn't know which PRs you own — you name them.
+
+**Targets — Builder seat.** Every open PR you own in this province, plus any new PR you open during the session (subscribe on open).
+
+```
+# Initial list-then-subscribe:
+list_pull_requests(owner=rishabh1804, repo=<your-province>, state=open)
+for each PR you own:
+    subscribe_pr_activity(owner=rishabh1804, repo=<your-province>, pullNumber=PR.number)
+
+# After opening a new PR mid-session:
+subscribe_pr_activity(owner=rishabh1804, repo=<your-province>, pullNumber=<new>)
+```
+
+**Event posture — Builder.**
+- Triage every event. Fix small/obvious issues on-branch.
+- Ask on ambiguity — Sovereign / Aurelius, not self-resolved.
+- Skip when no action is required.
+- **Never merge.** Sovereign merges (Standing rule 1).
 
 ---
 


### PR DESCRIPTION
Ratifies **Standing Rule 6 (Subscription & event posture)** across the War Time 2026-04-24 campaign. Every briefing now opens with an explicit \`subscribe_pr_activity\` directive baked into the copy-paste opening prompt, plus a role-specific event posture that overrides the generic webhook-subscription default (which is Builder-biased and structurally wrong for Reviewer and Chronicler seats).

## Triggering incident

At Hour ~5, Lyra's r2/r3/r4 pushes on sproutlab#4 and the rebase on sproutlab#5 went unseen in Cipher's running review session. The r1 opening prompt had inherited the generic \"investigate; fix if small; ask if ambiguous; skip if no action needed\" default — no explicit \`subscribe_pr_activity\` call. Webhooks routed nowhere. Recovery required an Architect nudge.

The gap was systemic: every briefing inherited the same omission, and the generic default's \"fix it on their branch\" clause is forbidden for the Reviewer seat (review authority only) and the Chronicler seat (read-only on province repos per Edict II).

## What's in this PR

**Briefings updated (7):**
- \`WAR_TIME_2026-04-24_AURELIUS_WAR_TRACKER.md\` — rule 6 in the standing-rules numbered list + ritual + opening-prompt directive
- \`WAR_TIME_2026-04-24_LYRA_SPROUTLAB_PHASE_1.md\` — Builder-seat ritual + directive
- \`WAR_TIME_2026-04-24_NYX_SOVEREIGN_DASHBOARD_PHASE_1-2.md\` — Builder+Sovereign ritual + directive
- \`WAR_TIME_2026-04-24_THERON_SOLARA_INVOICING_PHASE_1.md\` — Builder+Sovereign ritual + directive
- \`WAR_TIME_2026-04-24_CIPHER_REVIEW_SL-1-1.md\` — Reviewer-seat ritual + directive (sproutlab#3)
- \`WAR_TIME_2026-04-24_CIPHER_REVIEW_SL-1-2-R3_SL-1-3.md\` — Reviewer-seat dual-PR ritual + directive (sproutlab#4, #5)
- \`WAR_TIME_2026-04-24_CIPHER_REVIEW_SL-1-1_R2.md\` — Reviewer-seat ritual + directive (sproutlab#3); note: this briefing wasn't in the original 6-set but is a War Time Cipher briefing, so rule 6 bakes in consistently

**Canons (\`data/canons.json\`):**
- \`lore-2026-04-24-session-subscriptions-not-baked-in\` (Cautionary Tale) — captures the incident, the fix, and the lessons. Referenced by every briefing's ritual section.

## Seat-specific postures (canonical summary)

| Seat | Subscription target | Event posture (non-generic clauses) |
|---|---|---|
| Builder | PRs they own (+ new PRs on open) | Triage; fix small on-branch; ask on ambiguity; never merge |
| Reviewer (Cipher) | PRs they are reviewing | Diff-equivalence check on rebase → "approval stands"; else new verdict; never merge; no commits |
| Chronicler (Aurelius) | Every active province PR + every open Codex PR | Observe/record/ingest; update \`campaigns.json\`; read-only on province repos (Edict II); never push fixes |
| Sovereign | Discretion | Rule-1 merge authority |

## Ratification + durability

- Ratified 2026-04-24 by Sovereign in-session.
- Reverts with the campaign unless re-ratified (rules-1-5 precedent — War Time standing rules are scoped to the campaign).
- Post-war, Working Committee reviews whether rule 6 deserves Book VI amendment or standalone canon promotion.

## Merge path

Per War Time standing rule 2 (Chronicler self-merge for non-structural): Aurelius self-merges. Docs + canons-JSON only, no code surfaces touched.

## Post-merge bookkeeping

- Replenish \`claude/chronicler-reserve-1\` to fresh main (standing rule 4).
- \`claude/chronicler-reserve-2\` remains untouched; pool returns to 2.

Co-authored-by: Claude <noreply@anthropic.com>