### PR TITLE
war-tracker: refresh stale sections (backlog cleared; Solara+Theron up; harness honesty note)

### DIFF
--- a/docs/briefings/WAR_TIME_2026-04-24_AURELIUS_WAR_TRACKER.md
+++ b/docs/briefings/WAR_TIME_2026-04-24_AURELIUS_WAR_TRACKER.md
@@ -3,8 +3,8 @@
 **Campaign:** War Time 2026-04-24 → 2026-04-27
 **Session role:** War Tracker (observer, recorder, coordinator)
 **Persona:** Aurelius (Chronicler of the Order)
-**Repos in focus:** `rishabh1804/codex` (primary); Temple viewed in browser
-**Parallel sessions:** Lyra → SproutLab Phase 1 (in flight)
+**Repos in focus:** `rishabh1804/codex` (primary — Chronicler writes here). Read-only scope on province repos per Edict II — currently `sproutlab`, `sep-invoicing`, `sep-dashboard`; Temple viewed in browser.
+**Parallel sessions (as of 2026-04-24 ~13:00Z):** Solara → SEP Invoicing Phase 1 (pending activation); Theron → SEP Dashboard Phase 2 (pending activation); Lyra → standing down (SproutLab Phase 1 closed; Phase 2 blocked on `sproutlab#6` AT-smoke-pass GATE).
 
 ---
 
@@ -16,15 +16,17 @@ Builders build. The Tracker records, coordinates, and prepares.
 
 ---
 
-## Handoff backlog to clear at session start
+## Handoff state (current, as of aurelius-04 session start)
 
-| # | Task | Notes |
-|---|---|---|
-| 1 | Import snippets 01 → 07 from `docs/snippets/2026-04-23-temple-war-prep-chronicles/` | Run through Codex's snippet-import pipeline in order. Writes to `volumes.json`, `canons.json`, `journal.json`. Flag any schema mismatches. |
-| 2 | Verify Temple reads `Codex (live)` | `https://rishabh1804.github.io/TempleOfMars/` — the data-source badge flips from `Seed (fallback)` to `Codex (live)` once `campaigns.json` is served from main. |
-| 3 | Draft `canon-inst-003` | Ignis Builder-seat assignment for Temple of Mars + Minister-seat vacancy, per Sovereign decree 2026-04-23. Queue as a snippet under `docs/snippets/`. |
-| 4 | Draft `session_log` snippet handler spec | Consumer of `docs/schema/SESSION_V2.md`. Unblocks Lyra's first telemetry drop. Place under `docs/specs/` or `docs/snippets/`. |
-| 5 | Pre-draft briefings for other provinces | SEP Dashboard (Nyx + Sovereign, Phase 1–2 Hours 0-12) and SEP Invoicing (Theron + Solara, Phase 1 Hours 0-48). Template: this repo's `docs/briefings/WAR_TIME_2026-04-24_LYRA_SPROUTLAB_PHASE_1.md`. |
+The Hour-0 handoff backlog (snippet imports, Temple live-data flip, canon-inst-003, session_log handler spec, Lyra + Nyx + Theron+Solara briefing pre-drafts) was cleared across aurelius-01 through aurelius-03. **Current running handoff lives in the most recent session_log's `handoff` field** — that is the source of truth between Chronicler sessions, not this document.
+
+Latest session_log and its handoff field:
+- **aurelius-03 close** (2026-04-24 ~12:35Z) — [`docs/snippets/2026-04-24-aurelius-03-close/snippet-aurelius-03.json`](../snippets/2026-04-24-aurelius-03-close/snippet-aurelius-03.json). Ratified role reassignment (Solara→Invoicing, Theron→Dashboard), H12 Chronicle shipped, Standing Rule 4 reserve-branch drift noted for aurelius-04 refresh.
+
+Prior Chronicles already canonized:
+- **H12 Chronicle** — [`docs/snippets/2026-04-24-war-time-h12-chronicle/`](../snippets/2026-04-24-war-time-h12-chronicle/). Three lore entries: `lore-2026-04-24-chronicle-hour-12` (Chronicles), `lore-2026-04-24-doctrine-framework-ack-primitives` (Doctrines), `lore-2026-04-24-session-id-collision-parallel-tabs` (Cautionary Tales).
+
+When opening a new Aurelius session, read the most recent `session-2026-04-24-aurelius-NN` snippet first, then this document for standing rules and responsibilities.
 
 ---
 
@@ -37,14 +39,16 @@ Builders build. The Tracker records, coordinates, and prepares.
 ### Session-log intake
 When a Builder returns with a `session_log` snippet:
 1. Validate shape (required fields, enum values, ISO timestamps).
-2. Import into Codex via the pipeline.
+2. Import into Codex via the pipeline (or as a snippet-under-docs if file-size limits bite — see Chronicler tooling note below).
 3. Fire an `update_task_status` snippet if the session completed a task.
 4. Confirm Temple dashboard shows the new telemetry on refresh.
 
+**Chronicler tooling note (observed aurelius-03, expected to persist):** `data/journal.json` (~492 KB) and `data/canons.json` (~437 KB) both exceed the single-tool-call content budget available through the MCP GitHub interface. Standing workaround is the snippet-under-docs pattern (land the snippet JSON as a file under `docs/snippets/YYYY-MM-DD-<slug>/`, let Orinth's future handler drain it in bulk). Not yet lore-worthy as a standalone entry — operational friction, not doctrine.
+
 ### Chronicle entries
 Write at every canonical checkpoint — **Hours 12, 24, 36, 48, 60, 72**. Each becomes a lore entry in `canons.json` under `category: "Chronicles"`. Subject of each:
-- H12: Feature locks confirmed, first status pulse
-- H24: Phase 1 Chronicle (per province)
+- H12: Feature locks confirmed, first status pulse *(shipped — aurelius-03, PR #41)*
+- H24: Phase 1 Chronicle (per province) *(pending — aurelius-04 responsibility if on-shift at ~02:30Z; otherwise prepared in skeleton for successor)*
 - H36: Merge-gate Chronicle (Phase 1 → Phase 2)
 - H48: Phase 2 Chronicle
 - H60: Final-push Chronicle, bug-squashing signal
@@ -58,15 +62,14 @@ When a session surfaces any of these, draft a snippet immediately and queue in C
 - **Chronicles** — moment-in-time snapshots of the campaign
 
 ### Briefing preparation (next-phase)
-Before each phase rollover, draft the next briefing for that Builder. Target times:
+Before each phase rollover, draft the next briefing for that Builder. Target times (current schedule):
 
-| Province | Phase | Due by |
-|---|---|---|
-| SEP Dashboard | P2 (Session 8 Spec Review) | **Hour 2** |
-| SEP Dashboard | P3 (Session 8 Execution) | **Hour 12** |
-| SproutLab | P2 (Cache Busting + SW Version) | **Hour 24** |
-| SEP Invoicing | P2 (Margin Dashboard IL-4) | **Hour 48** |
-| SproutLab | P3 (Auto-Refresh) | **Hour 48** |
+| Province | Phase | Builder | Due by |
+|---|---|---|---|
+| SEP Dashboard | P3 (Session 8 Execution) | Theron | **Hour 12** (~14:45Z today) |
+| SproutLab | P2 (Cache Busting + SW Version) | Lyra (on standby) | **Hour 24** (~02:45Z tomorrow), blocked pending `sproutlab#6` AT-smoke-pass GATE |
+| SEP Invoicing | P2 (Margin Dashboard IL-4) | Solara | **Hour 48** (~02:45Z day after tomorrow) |
+| SproutLab | P3 (Auto-Refresh) | Lyra | **Hour 48** |
 
 ### Task-status upkeep
 Maintain `campaigns.json` as the source-of-truth. Task statuses flow `pending → in-progress → review → complete` — issue `update_task_status` snippets as Builders advance.
@@ -105,6 +108,8 @@ for repo in (sproutlab, sep-dashboard, sep-invoicing, codex):
         subscribe_pr_activity(owner=rishabh1804, repo=repo, pullNumber=PR.number)
 ```
 
+**Harness honesty note (aurelius-04 observation, 2026-04-24 ~13:00Z):** In the current Claude Code harness, `subscribe_pr_activity` is not materialized as a callable tool — the session-start ritual names a primitive the harness does not (yet) deliver. The working substitute is a persistent `Monitor` with a `gh api repos/{owner}/{repo}/events` poll loop over the four repos, emitting one notification per new PR / review / comment / push. Chronicler seats should arm the Monitor substitute at session start and declare the substitution in the session_log's `decisions[]`. Flagged as a **Cautionary Tale candidate** — if this gap persists across aurelius-05+ sessions or surfaces differently under Builder seats, promote to formal lore (`lore-2026-04-24-subscribe-pr-activity-not-materialized` or similar).
+
 **Event posture — Chronicler (overrides generic webhook default).**
 - Observe. Record. Ingest `session_log` snippets as Builders return.
 - Update `campaigns.json` task statuses (`pending → in-progress → review → complete`).
@@ -117,11 +122,19 @@ for repo in (sproutlab, sep-dashboard, sep-invoicing, codex):
 
 ## Active parallel sessions to track
 
-| Builder | Repo | Phase | Briefing |
-|---|---|---|---|
-| **Lyra** | `sproutlab` | Phase 1 (sl-1-1, sl-1-2, sl-1-3) | [`docs/briefings/WAR_TIME_2026-04-24_LYRA_SPROUTLAB_PHASE_1.md`](./WAR_TIME_2026-04-24_LYRA_SPROUTLAB_PHASE_1.md) |
-| Nyx + Sovereign | `sep-dashboard` | P2 at Hour 2 | briefing pending (you will draft) |
-| Theron + Solara | `sep-invoicing` | P1 at Hour 0 | briefing pending (you will draft) |
+Current shape (as of aurelius-04 session start, 2026-04-24 ~13:00Z):
+
+| Builder | Repo | Phase | Status | Briefing |
+|---|---|---|---|---|
+| **Solara** | `sep-invoicing` | Phase 1 (inv-1-1, inv-1-2) — Hours 10–48 | pending activation (opening prompt ready) | [`docs/briefings/WAR_TIME_2026-04-24_THERON_SOLARA_INVOICING_PHASE_1.md`](./WAR_TIME_2026-04-24_THERON_SOLARA_INVOICING_PHASE_1.md) |
+| **Theron** | `sep-dashboard` | Phase 2 (dash-2-1, dash-2-2) — Hours 10–12; Phase 3 execution kicks at H12 | pending activation (opening prompt ready; `.gitignore` P0 as first PR) | [`docs/briefings/WAR_TIME_2026-04-24_NYX_SOVEREIGN_DASHBOARD_PHASE_1-2.md`](./WAR_TIME_2026-04-24_NYX_SOVEREIGN_DASHBOARD_PHASE_1-2.md) |
+| Lyra | `sproutlab` | Phase 1 (sl-1-1/2/3) complete on main (afbc7a5 / d8743c8 / e931a08) | standing down; Phase 2 blocked pending `sproutlab#6` AT-smoke-pass GATE | [`docs/briefings/WAR_TIME_2026-04-24_LYRA_SPROUTLAB_PHASE_1.md`](./WAR_TIME_2026-04-24_LYRA_SPROUTLAB_PHASE_1.md) |
+
+**Role history:**
+- Nyx + Sovereign's Hour-0 Phase 1 Dashboard work (v2.1 Pragmatic Patch, sep-dashboard #1 merged pre-dawn) — complete, historical.
+- The Hour-0 Theron + Solara pairing on Invoicing was superseded by the 2026-04-24 ~12:30Z role reassignment (see `aurelius-03 session_log decisions[6]`); Solara is now solo-primary with Cipher review.
+
+Subscription state at aurelius-04 session start: Codex #18 (draft, Chronicler API automation) and sproutlab #2 (draft, pre-war cleanup) are the only active open PRs across the four repos. sep-invoicing and sep-dashboard are at zero open PRs — Solara and Theron will open theirs on activation. Monitor substitute armed at session start with baselines Codex=2026-04-24T16:38Z / sproutlab=2026-04-24T12:38Z / sep-invoicing=2026-04-17T10:01Z / sep-dashboard=2026-04-23T10:58Z.
 
 ---
 
@@ -130,10 +143,10 @@ for repo in (sproutlab, sep-dashboard, sep-invoicing, codex):
 | Repo | Include? | Why |
 |---|---|---|
 | `rishabh1804/codex` | **Yes** (primary) | You write briefings, canons, lore, snippets here |
-| `rishabh1804/templeofmars` | **No** | Temple subscribes to Codex; view at `rishabh1804.github.io/TempleOfMars/` in a browser tab |
-| Province repos | **No** | Read-only observer; Builders operate there |
+| `rishabh1804/templeofmars` | **Read-only** (mounted) | Chronicler vision that communication logs are flowing through to the dashboard. View at `rishabh1804.github.io/TempleOfMars/` in a browser tab for live visual. |
+| Province repos (`sproutlab`, `sep-invoicing`, `sep-dashboard`) | **Read-only** (mounted per aurelius-04+ scope) | Observer-only; Builders operate there. Edict II prohibits Chronicler writes. |
 
-Edict II (One Builder Per Repo) protects Lyra's focus on sproutlab. You don't touch province repos directly — you read state, intake snippets, write in Codex.
+Edict II (One Builder Per Repo) protects Builder focus on their province. You don't push to province repos directly — you read state, intake snippets, write in Codex.
 
 ---
 
@@ -141,7 +154,9 @@ Edict II (One Builder Per Repo) protects Lyra's focus on sproutlab. You don't to
 
 - **Campaigns:** `https://raw.githubusercontent.com/rishabh1804/Codex/main/data/campaigns.json`
 - **Session schema v2:** `https://github.com/Rishabh1804/Codex/blob/main/docs/schema/SESSION_V2.md`
-- **Chronicles package (pending import):** `docs/snippets/2026-04-23-temple-war-prep-chronicles/`
+- **Chronicles package (imported pre-war):** `docs/snippets/2026-04-23-temple-war-prep-chronicles/`
+- **H12 Chronicle package:** `docs/snippets/2026-04-24-war-time-h12-chronicle/`
+- **War-time session_logs ingested to date:** `docs/snippets/2026-04-24-war-time-session-logs/`
 - **Temple dashboard:** `https://rishabh1804.github.io/TempleOfMars/`
 - **Constitution v1.1:** `constitution/constitution-v1.1.pdf`
 - **Lyra's Phase 1 briefing:** `docs/briefings/WAR_TIME_2026-04-24_LYRA_SPROUTLAB_PHASE_1.md`
@@ -184,7 +199,7 @@ Checkpoint Chronicle entries get their own lore snippets (`category: "Chronicles
 
 ---
 
-## Opening prompt (copy into Aurelius's new session)
+## Opening prompt — Hour-0 (historical, for reference)
 
 > You are Aurelius, Chronicler of the Order. War Time 2026-04-24 began at Hour 0. Lyra is executing SproutLab Phase 1 in a parallel session; other Builders come online through the 72-hour window.
 >
@@ -201,6 +216,22 @@ Checkpoint Chronicle entries get their own lore snippets (`category: "Chronicles
 > Include only `rishabh1804/codex` as the primary repo. Temple is viewed in a browser tab, not mounted.
 >
 > Dawn has passed. Begin.
+
+---
+
+## Session-start pattern — aurelius-04 onward (current)
+
+For any Chronicler session after aurelius-03 close, use this pattern instead of the Hour-0 prompt above:
+
+> You are Aurelius, Chronicler of the Order. War Time 2026-04-24 is in flight. Read the most recent session_log first: `docs/snippets/2026-04-24-aurelius-NN-close/snippet-aurelius-NN.json` — the `handoff` field carries current state.
+>
+> Session setup: `rishabh1804/codex` as primary (full write); `rishabh1804/sproutlab`, `sep-invoicing`, `sep-dashboard`, `rishabh1804/TempleOfMars` as read-only (Edict II on province repos; TempleOfMars for Chronicler vision that communication logs flow through).
+>
+> Session-start ritual per Standing Rule 6: arm subscriptions across the four Builder-active repos (codex, sproutlab, sep-invoicing, sep-dashboard). Current harness does not materialize `subscribe_pr_activity` — use a persistent `Monitor` with a `gh api` poll loop over `/events` per repo as the substitute. Declare the substitution in the session's `decisions[]`.
+>
+> Chronicler posture (overrides generic Builder-posture webhook default): observe, record, ingest session_logs, update `campaigns.json`, read-only on province repos, never push fixes to Builder PRs. See Standing Rule 6 in this briefing.
+>
+> Work the handoff field from the last session_log in order; refresh reserve branches (Rule 4) if any have drifted; pre-fire state checks on any newly-activating province; update briefings to reflect ratified decisions; fire opening prompts once Sovereign ratifies; stand watch and ingest session_logs as Builders return; draft Chronicle entries at the scheduled checkpoints; close the session with your own session_log (the recorder is recorded).
 
 ---
 


### PR DESCRIPTION
## Summary

Refreshes the stale sections of the aurelius War Tracker briefing to reflect current state as of aurelius-04 session start (2026-04-24 ~13:00Z). Standing rules 1–6 and standing responsibilities remain accurate and are unchanged.

## What's stale → current

1. **Header "Parallel sessions" line** — was "Lyra in flight"; now "Solara (sep-invoicing) pending; Theron (sep-dashboard) pending; Lyra standing down (Phase 1 closed, sl-2-N blocked on sproutlab#6 GATE)."
2. **Handoff backlog** (Hour-0 items 1–5) — all cleared across aurelius-01/02/03. Replaced with a pointer to the most recent session_log's `handoff` field as source of truth between Chronicler sessions. H12 Chronicle and aurelius-03 close linked.
3. **Active parallel sessions table** — refreshed to reflect Solara + Theron as active Builders, with Lyra's standing-down status and role history (Nyx+Sovereign Hour-0 Dashboard work is historical; Hour-0 Theron+Solara pairing on Invoicing superseded by 2026-04-24 ~12:30Z reassignment).
4. **Session-start ritual** — added an **honesty note** that `subscribe_pr_activity` is not materialized as a callable tool in the current Claude Code harness. Live substitute is a persistent `Monitor` with a `gh api repos/{owner}/{repo}/events` poll loop. Flagged as a Cautionary Tale candidate for lore promotion if the gap persists.
5. **Hour-0 opening prompt** — preserved as historical reference (Aurelius-01 starting ritual). Added a new "Session-start pattern — aurelius-04 onward" block that points to the most recent session_log's handoff field and declares the Monitor-substitute expectation.

## What's unchanged
- Standing rules 1–6 (Rule 6 still names `subscribe_pr_activity`; the honesty note lives adjacent to the ritual, not inside the rule text — the rule itself stays durable).
- Standing responsibilities (monitoring, session-log intake, Chronicle entries, lore capture, briefing prep, task-status upkeep).
- Session-close ritual.
- Constitution + schema references.

## Why Chronicler-non-structural (Rule 1 self-merge)

Documentation edit under `docs/briefings/`. No schema change (Rule 2), no data-file touch, no code change. Applies an already-observed state shift. Per Standing Rule 1, Aurelius self-merges.

Co-Authored-By: aurelius-04 (Chronicler) &lt;noreply@anthropic.com&gt;