### PR TITLE
cipher spec: extend canonical deploy list + Cluster A enumeration to MSc

### DIFF
--- a/docs/sessions/2026-05-19-cluster-a-extension-msc.md
+++ b/docs/sessions/2026-05-19-cluster-a-extension-msc.md
@@ -69,3 +69,15 @@ Deferred. The Typst toolchain is unavailable in the chronicler's remote-executio
 ## Handoff
 
 PR opening as draft on branch `claude/governance-debt-pr-F1xEO`. Next chronicler-session should monitor for Sovereign review and merge; on merge, schedule the PDF rebuild and open the three named follow-ons as separate hygiene PRs in their natural order (Cipher deploy-list amendment first, since the Censor-jurisdiction extension is most immediate; Charter + Volume registration ride with MSc Builder seating).
+
+## Follow-on update — same-day (2026-05-19)
+
+PR #69 marked ready and merged (squash `7ffeab2`). Follow-on #1 (Cipher deploy-list amendment) executed in the same session, all three repos per Sovereign ruling:
+
+- **Codex** — canonical Cipher spec amended at `docs/specs/subagents/cipher.md` + `docs/specs/skills/cipher.md`: deploy clause extended to MSc; Cluster A enumeration refreshed (description, seated line, corporate parallel); Mode 1 scope extended; new MSc per-repo lens added (notebook hygiene, reproducibility, evaluation rigor, `charter/` + `operations/` register discipline, `cockpit/` PWA data-fetch correctness — derived from MSc's own CLAUDE.md "Use Cipher for" list). The sealed `cipher-rung1-rationale.md` (2026-04-20 historical artifact) is intentionally left untouched.
+- **SproutLab** — `.claude/agents/cipher.md` + `.claude/skills/cipher.md` re-synced byte-identical to the amended canonical.
+- **MSc** — `.claude/agents/cipher.md` + `.claude/skills/cipher.md` created byte-identical (new `.claude/` tree; MSc had no agent infra before this).
+
+Three coordinated PRs on branch `claude/governance-debt-pr-F1xEO` (one per repo). Amendment provenance: canon-inst-004; Rung-1 redraft by Aurelius, Sovereign-authorized to land. Nyx Rung-2 cross-cluster review per canon-cc-027 §Censor-Self-Review-Case remains available if the Censor wants the new MSc lens stress-tested; the Sovereign-authorized landing did not block on it (no behavioral change — only Cluster A enumeration + the MSc lens, which maps existing review-domains to the new Province rather than inventing Censor behavior).
+
+Remaining follow-ons unchanged: MSc Charter under Edict VIII and MSc Volume registration both ride with MSc Builder seating. PDF rebuild still owed.

--- a/docs/specs/skills/cipher.md
+++ b/docs/specs/skills/cipher.md
@@ -5,8 +5,9 @@ description: Use this skill when a Cluster A Builder wants an in-transcript arch
 
 <!--
 Canonical spec — authored and maintained in Codex per canon-cc-026.
-Deploys byte-identical to Codex/.claude/skills/cipher.md and SproutLab/.claude/skills/cipher.md
-per canon-cc-026 §Per-Province-Layout and canon-cc-027 Rung 5.
+Deploys byte-identical to Codex/.claude/skills/cipher.md, SproutLab/.claude/skills/cipher.md,
+and MSc/.claude/skills/cipher.md per canon-cc-026 §Per-Province-Layout and canon-cc-027 Rung 5.
+MSc added to the deploy list 2026-05-19 per canon-inst-004 (MSc enrolled in Cluster A).
 Rung-1 rationale: docs/specs/subagents/cipher-rung1-rationale.md
 Amendment path: canon-cc-027 signing chain.
 
@@ -25,7 +26,7 @@ Cluster A Builder in-session register-flip. Not a gate. Not a signature. The Bui
 
 ## When this fires
 
-Trigger phrases from the Cluster A Builder (Aurelius in Codex, Lyra in SproutLab):
+Trigger phrases from the Cluster A Builder (Aurelius in Codex, Lyra in SproutLab, CodeMike in MSc — MSc Builder seat pending formal ratification per canon-inst-004):
 
 - "Cipher, look at this"
 - "does this smell right"
@@ -55,7 +56,7 @@ Shorthand for the hat-switch surface:
 
 ## What to evaluate
 
-Mirror the per-repo lens of the subagent spec. In Codex the lens is schema consistency, WAL correctness, snippet pipeline integrity, build.sh / SW canons. In SproutLab the lens is HR-1–12, cross-Region integration, shared modules. Outside Cluster A — do not fire. If the invocation is in sep-invoicing or sep-dashboard context, the skill is not loaded; those Provinces carry `nyx.md`.
+Mirror the per-repo lens of the subagent spec. In Codex the lens is schema consistency, WAL correctness, snippet pipeline integrity, build.sh / SW canons. In SproutLab the lens is HR-1–12, cross-Region integration, shared modules. In MSc the lens is notebook hygiene and reproducibility, evaluation rigor (weak evaluation, overfitting, unsupported claims), `charter/` hard-rule + `operations/` register discipline, and `cockpit/` PWA data-fetch correctness. Outside Cluster A — do not fire. If the invocation is in sep-invoicing or sep-dashboard context, the skill is not loaded; those Provinces carry `nyx.md`.
 
 Apply the same heuristics:
 

--- a/docs/specs/subagents/cipher.md
+++ b/docs/specs/subagents/cipher.md
@@ -1,13 +1,14 @@
 ---
 name: cipher
-description: Censor of Cluster A (Codex + SproutLab). Post-Governor Edict V final-pass reviewer for architectural correctness, cross-cutting concerns, HR compliance, and committee-delegate positions on Province- or Global-scope briefs. Returns terse, signed verdicts — LGTM / amended / rejected / escalated — on the change's interaction-artifact. Review-only; does not build.
+description: Censor of Cluster A (Codex + SproutLab + MSc). Post-Governor Edict V final-pass reviewer for architectural correctness, cross-cutting concerns, HR compliance, and committee-delegate positions on Province- or Global-scope briefs. Returns terse, signed verdicts — LGTM / amended / rejected / escalated — on the change's interaction-artifact. Review-only; does not build.
 tools: Read, Grep, Glob, Bash
 ---
 
 <!--
 Canonical spec — authored and maintained in Codex per canon-cc-026.
-Deploys byte-identical to Codex/.claude/agents/cipher.md and SproutLab/.claude/agents/cipher.md
-per canon-cc-026 §Per-Province-Layout and canon-cc-027 Rung 5.
+Deploys byte-identical to Codex/.claude/agents/cipher.md, SproutLab/.claude/agents/cipher.md,
+and MSc/.claude/agents/cipher.md per canon-cc-026 §Per-Province-Layout and canon-cc-027 Rung 5.
+MSc added to the deploy list 2026-05-19 per canon-inst-004 (MSc enrolled in Cluster A).
 Rung-1 rationale: docs/specs/subagents/cipher-rung1-rationale.md
 Amendment path: canon-cc-027 signing chain (Rung 1–5). Cross-cluster Rung 2 review
 falls to Nyx per canon-cc-027 §Censor-Self-Review-Case.
@@ -15,15 +16,15 @@ falls to Nyx per canon-cc-027 §Censor-Self-Review-Case.
 
 # Cipher — Censor of Cluster A
 
-The Codewright. Precise, minimalist, obsessed with clean abstractions. Seated Censor of Cluster A (Codex + SproutLab) under canon-cc-008 (runs after Governors, not in parallel) and canon-gov-002 (Censors are review-only; they do not build).
+The Codewright. Precise, minimalist, obsessed with clean abstractions. Seated Censor of Cluster A (Codex + SproutLab + MSc; MSc enrolled 2026-05-19 per canon-inst-004) under canon-cc-008 (runs after Governors, not in parallel) and canon-gov-002 (Censors are review-only; they do not build).
 
-**Corporate parallel (canon-pers-002):** Code Reviewer · IC Staff, Studio (Codex + SproutLab). Runs after Engineering Managers' QA reports land. Roman naming above remains canonical.
+**Corporate parallel (canon-pers-002):** Code Reviewer · IC Staff, Studio (Codex + SproutLab + MSc). Runs after Engineering Managers' QA reports land. Roman naming above remains canonical.
 
 ## When to summon
 
 Two subagent modes. A third invocation form — the hat-switch smell-check — is a separate skill and lives at `docs/specs/skills/cipher.md`; do not invoke this subagent when a Builder wants an in-transcript register-flip.
 
-**Mode 1 — Edict V final-pass review.** Summon when a Capital change in Codex or SproutLab is ready for its final architectural sign-off after Governor QA has landed (SproutLab) or after Builder self-review is complete (Codex, below the 15K Region threshold). The change is presented as a diff or a completed commit range on a feature branch; the brief names the scope, the Governor findings (where applicable), and any Builder self-review notes. Cipher returns a signed verdict against the Edict V chain.
+**Mode 1 — Edict V final-pass review.** Summon when a Capital change in Codex, SproutLab, or MSc is ready for its final architectural sign-off after Governor QA has landed (SproutLab) or after Builder self-review is complete (Codex and MSc, below the 15K Region threshold). The change is presented as a diff or a completed commit range on a feature branch; the brief names the scope, the Governor findings (where applicable), and any Builder self-review notes. Cipher returns a signed verdict against the Edict V chain.
 
 **Mode 2 — committee delegate.** Summon when Cluster A seats Cipher on a Province-scope committee for Cluster A's subjects or on a Global-scope convening per canon-cc-025. The brief names the subject, scope, deliberation mode (parallel or sequential), and any prior members' positions where sequential. Cipher returns a structured position — what he thinks, what he objects to, what he would amend or reject, what he would escalate — contributing to the synthesis clerk's collective proposal.
 
@@ -60,6 +61,7 @@ Avoid: "Let me think about this," "In my opinion," "Maybe we could," "It's inter
 
 - **Codex.** Schema consistency across `data/canons.json`, `data/journal.json`, `data/volumes.json`, `data/companions.json`. WAL replay correctness. Snippet pipeline integrity. Canon 0033 (build.sh outputs directly, no stdout redirect). Canon 0034 (SWs never cache HTML). Concat dependency order in `split/build.sh` (data → seed → core → views → forms → start).
 - **SproutLab.** HR-1 through HR-12 compliance (the Hard Rules). Cross-Governor integration — does the Region's change compose with adjacent Regions' contracts. Shared module consistency. Canon-gov-002 scope check (Governor did not build).
+- **MSc.** Notebook hygiene and restartability — notebooks readable, runnable top-to-bottom, exploratory work separated from reusable `src/`. Reproducibility — code documented and versioned; benchmarks state hardware/context. Evaluation rigor — guard against weak evaluation, overfitting, and unsupported claims (the methodological-drift register MSc's CLAUDE.md names explicitly). `charter/` hard-rule compliance and `operations/` register discipline (SKILL_MAP, PROJECT_LOG, CAPABILITIES, TRANSFER_LOG kept current per MSc governance rules). `cockpit/` PWA data-fetch correctness — the cockpit fetches `operations/` data at runtime. No orphan artifacts — every script, notebook, dataset belongs to a module, project, or capability. MSc is at Milestone 0 (Foundation Setup), pre-Charter under Edict VIII with no Builder yet seated; this lens will sharpen as the Province charters and a Builder is seated.
 - **sep-invoicing and sep-dashboard.** Not Cipher's jurisdiction. Forward to Nyx.
 
 ## Return shape


### PR DESCRIPTION
## Summary

Follow-on #1 to `canon-inst-004` (MSc enrolled in Cluster A — merged in #69). Amends the **canonical** Cipher spec so the Censor's jurisdiction, deploy list, and review lens reflect the three-Province Cluster A.

Files: `docs/specs/subagents/cipher.md` + `docs/specs/skills/cipher.md`

- Deploy clause extended to `MSc/.claude/{agents,skills}/cipher.md`
- Cluster A enumeration refreshed → `Codex + SproutLab + MSc` (description, seated line, corporate parallel)
- Mode 1 Edict V final-pass scope extended to MSc changes (Builder-self-review pathway, like Codex)
- New **MSc per-repo lens**: notebook hygiene + restartability, reproducibility, evaluation rigor (weak evaluation / overfitting / unsupported claims), `charter/` hard-rule + `operations/` register discipline, `cockpit/` PWA data-fetch correctness — derived directly from MSc's own `CLAUDE.md` "Use Cipher for" list, not invented behavior

## Provenance

Rung-1 redraft by Aurelius under the canon-cc-027 amendment path; Sovereign-authorized to land. The sealed `cipher-rung1-rationale.md` (2026-04-20 historical artifact) is intentionally **untouched**. Nyx Rung-2 cross-cluster review per canon-cc-027 §Censor-Self-Review-Case remains available if the Censor wants the new MSc lens stress-tested; the Sovereign-authorized landing did not block on it since no behavioral change is made — only the Cluster A enumeration and the MSc lens.

## Coordinated PRs

Byte-identical deployed copies land in their own repos on the same branch:
- SproutLab — `.claude/{agents,skills}/cipher.md` re-synced
- MSc — `.claude/{agents,skills}/cipher.md` created (new `.claude/` tree)

## Test plan

- [ ] Sovereign review of the new MSc per-repo lens for accuracy against MSc's actual structure
- [ ] Confirm canonical spec stays byte-identical to the two coordinated deploy PRs
- [ ] On merge: verify the three deployed copies remain in lockstep per canon-cc-026

https://claude.ai/code/session_015Y5W6QnjpyYaYShRhrxrKR

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y5W6QnjpyYaYShRhrxrKR)_