### PR TITLE
Add SessionStart hook to install Typst for web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# SessionStart hook — installs Typst so the Constitution PDFs can be
+# rebuilt from .typ source during Claude Code on the web sessions.
+set -euo pipefail
+
+# Web sessions only; local machines manage their own toolchain.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+BIN_DIR="$HOME/.local/bin"
+mkdir -p "$BIN_DIR"
+
+# Persist PATH for the session (BIN_DIR is not on PATH by default).
+# Guarded so resume/compact re-fires don't append duplicate lines.
+PATH_LINE="export PATH=\"$BIN_DIR:\$PATH\""
+if [ -n "${CLAUDE_ENV_FILE:-}" ] && ! grep -qsF "$PATH_LINE" "$CLAUDE_ENV_FILE"; then
+  echo "$PATH_LINE" >> "$CLAUDE_ENV_FILE"
+fi
+export PATH="$BIN_DIR:$PATH"
+
+# Idempotent: skip the download if Typst is already present.
+if command -v typst >/dev/null 2>&1; then
+  echo "typst already installed: $(typst --version)" >&2
+  exit 0
+fi
+
+# Pinned version for reproducible PDF builds.
+TYPST_VERSION="v0.14.2"
+TARBALL="typst-x86_64-unknown-linux-musl"
+URL="https://github.com/typst/typst/releases/download/${TYPST_VERSION}/${TARBALL}.tar.xz"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+curl -sSL --retry 3 --max-time 180 -o "$TMP/typst.tar.xz" "$URL"
+tar -xf "$TMP/typst.tar.xz" -C "$TMP"
+install -m 0755 "$TMP/${TARBALL}/typst" "$BIN_DIR/typst"
+
+echo "typst installed: $("$BIN_DIR/typst" --version)" >&2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Claude Code on the web runs in an ephemeral container with no Typst toolchain, so the Constitution PDFs (`constitution-v1.1.pdf`, `working-papers-v1.pdf`) cannot be rebuilt from `.typ` source. This adds a `SessionStart` hook that installs Typst automatically.

- `.claude/hooks/session-start.sh` — installs a **pinned** Typst binary (`v0.14.2`) into `~/.local/bin` and persists it on `PATH` via `$CLAUDE_ENV_FILE`
- `.claude/settings.json` — registers the hook on `SessionStart`

**Properties:**
- **Web-only** — `CLAUDE_CODE_REMOTE` guard; local machines manage their own toolchain
- **Idempotent** — skips the download if Typst is already present; PATH line is dedup-guarded against resume/compact re-fires
- **Pinned version** — `v0.14.2` for reproducible PDF builds, not `latest`

## Validation

- Fresh install run — Typst downloaded + installed, reports `typst 0.14.2`
- Idempotent re-run — skips download, no duplicate PATH line
- `typst compile main.typ` — compiles the full Constitution cleanly (725 KB PDF, no errors)

Hook runs **synchronously** — the session waits for the install (a ~16 MB download) before starting. Trade-off: guarantees Typst is ready before any rebuild attempt, at the cost of slightly slower session startup. Can switch to async if preferred.

## Test plan

- [ ] Confirm the hook runs on the next web session and `typst` is on `PATH`
- [ ] Confirm `typst compile constitution/main.typ` works without manual install

https://claude.ai/code/session_015Y5W6QnjpyYaYShRhrxrKR

---
_Generated by [Claude Code](https://claude.ai/code/session_015Y5W6QnjpyYaYShRhrxrKR)_