### PR TITLE
Order view: surface the Scribe Worker Tier on the Ladder sub-tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -1133,6 +1133,12 @@ body {
 .cx-ladder-empty{font-size:var(--fs-xs);color:var(--text-tertiary);font-style:italic;padding:var(--sp-4) var(--sp-8)}
 .cx-ladder-seat-sovereign{font-family:var(--ff-heading);font-size:var(--fs-md);font-weight:700;color:var(--accent);padding:var(--sp-6) var(--sp-12);background:var(--bg-secondary);border-radius:var(--r-md);border:1px solid var(--accent-light);letter-spacing:0.3px}
 .cx-ladder-footnote{font-size:var(--fs-xs);color:var(--text-tertiary);font-style:italic;line-height:1.5;padding:var(--sp-8) 0;border-top:1px solid var(--border);margin-top:var(--sp-8)}
+.cx-ladder-tier{display:flex;flex-direction:column;gap:var(--sp-6);width:100%;padding:var(--sp-8) var(--sp-10);background:var(--bg-secondary);border:1px dashed var(--border);border-radius:var(--r-md)}
+.cx-ladder-tier-label{font-family:var(--ff-mono,monospace);font-size:var(--fs-2xs);color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.6px;font-weight:600}
+.cx-ladder-tier-note{font-size:var(--fs-xs);color:var(--text-secondary);line-height:1.5;margin:0}
+.cx-ladder-tier-specs{display:flex;flex-wrap:wrap;gap:var(--sp-6)}
+.cx-ladder-tier-spec{font-size:var(--fs-2xs);color:var(--text-secondary);background:var(--bg-card);border:1px solid var(--border);border-radius:var(--r-full);padding:var(--sp-2) var(--sp-8)}
+.cx-ladder-tier-spec strong{color:var(--text-primary);font-weight:700}
 
 /* ---- Companion Detail ---- */
 .cx-companion-detail-hero{background:var(--bg-card);border-radius:var(--r-lg);padding:var(--sp-20) var(--sp-16);margin-bottom:var(--sp-12);box-shadow:var(--card-shadow);border-left:3px solid var(--accent)}
@@ -5701,6 +5707,20 @@ var LADDER_RANKS = [
   { key: 'Scribe',    label: 'Scribes' }
 ];
 
+/* The Scribe rung is a worker tier, not a roster — canon-proc-006 / decree-0019,
+   Book II Article 3-bis. Like CABINET_STRUCTURE above, this is constitutional
+   structure and does not live in companions.json. */
+var SCRIBE_TIER = {
+  canon: 'canon-proc-006',
+  note: 'Each senior companion commands a detail of four task-specialised Scribes, deployed as subagents. The tier is intentionally unrostered — a rank-form, not named individuals.',
+  specialisations: [
+    { name: 'Scout',  role: 'reconnaissance' },
+    { name: 'Draft',  role: 'composition' },
+    { name: 'Verify', role: 'mechanical checks' },
+    { name: 'Record', role: 'chronicling' }
+  ]
+};
+
 function renderOrder() {
   var vc = document.getElementById('viewContainer');
   var companions = store.companions || [];
@@ -6022,18 +6042,37 @@ function renderOrderLadderSubTab(companions) {
     if (members.length > 0) html += ' <span class="cx-ladder-count">' + members.length + '</span>';
     html += '</div>';
     html += '<div class="cx-ladder-rank-occupants">';
-    if (members.length === 0) {
-      html += '<div class="cx-ladder-empty">None seated</div>';
-    } else {
+    if (members.length > 0) {
       members.forEach(function(c) { html += renderCompanionPill(c); });
+    } else if (r.key !== 'Scribe') {
+      html += '<div class="cx-ladder-empty">None seated</div>';
     }
+    // The Scribe rung is an unrostered worker tier — surface it as such
+    // rather than leaving the row reading "None seated" (canon-proc-006).
+    if (r.key === 'Scribe') html += renderScribeTierNote();
     html += '</div></div>';
   });
 
   html += '</div>';
 
-  html += '<div class="cx-ladder-footnote">Single-ladder per Constitution Book II Article 1. Military-track parallel (General/Centurion) and Treasury parallel (Collector) not yet seated.</div>';
+  html += '<div class="cx-ladder-footnote">Single-ladder per Constitution Book II Article 1. The Scribe rung is a worker tier (Article 3-bis), not a roster. Military-track parallel (General/Centurion) and Treasury parallel (Collector) not yet seated.</div>';
 
+  return html;
+}
+
+/* Renders the Scribe Worker Tier explainer on the Ladder's Scribe row.
+   The tier is constitutional structure (canon-proc-006), not roster data. */
+function renderScribeTierNote() {
+  var t = SCRIBE_TIER;
+  var html = '<div class="cx-ladder-tier">';
+  html += '<div class="cx-ladder-tier-label">Worker Tier · ' + escHtml(t.canon) + '</div>';
+  html += '<p class="cx-ladder-tier-note">' + escHtml(t.note) + '</p>';
+  html += '<div class="cx-ladder-tier-specs">';
+  t.specialisations.forEach(function(s) {
+    html += '<span class="cx-ladder-tier-spec"><strong>' + escHtml(s.name) + '</strong> '
+         +  escHtml(s.role) + '</span>';
+  });
+  html += '</div></div>';
   return html;
 }
 

--- a/split/codex.html
+++ b/split/codex.html
@@ -1133,6 +1133,12 @@ body {
 .cx-ladder-empty{font-size:var(--fs-xs);color:var(--text-tertiary);font-style:italic;padding:var(--sp-4) var(--sp-8)}
 .cx-ladder-seat-sovereign{font-family:var(--ff-heading);font-size:var(--fs-md);font-weight:700;color:var(--accent);padding:var(--sp-6) var(--sp-12);background:var(--bg-secondary);border-radius:var(--r-md);border:1px solid var(--accent-light);letter-spacing:0.3px}
 .cx-ladder-footnote{font-size:var(--fs-xs);color:var(--text-tertiary);font-style:italic;line-height:1.5;padding:var(--sp-8) 0;border-top:1px solid var(--border);margin-top:var(--sp-8)}
+.cx-ladder-tier{display:flex;flex-direction:column;gap:var(--sp-6);width:100%;padding:var(--sp-8) var(--sp-10);background:var(--bg-secondary);border:1px dashed var(--border);border-radius:var(--r-md)}
+.cx-ladder-tier-label{font-family:var(--ff-mono,monospace);font-size:var(--fs-2xs);color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.6px;font-weight:600}
+.cx-ladder-tier-note{font-size:var(--fs-xs);color:var(--text-secondary);line-height:1.5;margin:0}
+.cx-ladder-tier-specs{display:flex;flex-wrap:wrap;gap:var(--sp-6)}
+.cx-ladder-tier-spec{font-size:var(--fs-2xs);color:var(--text-secondary);background:var(--bg-card);border:1px solid var(--border);border-radius:var(--r-full);padding:var(--sp-2) var(--sp-8)}
+.cx-ladder-tier-spec strong{color:var(--text-primary);font-weight:700}
 
 /* ---- Companion Detail ---- */
 .cx-companion-detail-hero{background:var(--bg-card);border-radius:var(--r-lg);padding:var(--sp-20) var(--sp-16);margin-bottom:var(--sp-12);box-shadow:var(--card-shadow);border-left:3px solid var(--accent)}
@@ -5701,6 +5707,20 @@ var LADDER_RANKS = [
   { key: 'Scribe',    label: 'Scribes' }
 ];
 
+/* The Scribe rung is a worker tier, not a roster — canon-proc-006 / decree-0019,
+   Book II Article 3-bis. Like CABINET_STRUCTURE above, this is constitutional
+   structure and does not live in companions.json. */
+var SCRIBE_TIER = {
+  canon: 'canon-proc-006',
+  note: 'Each senior companion commands a detail of four task-specialised Scribes, deployed as subagents. The tier is intentionally unrostered — a rank-form, not named individuals.',
+  specialisations: [
+    { name: 'Scout',  role: 'reconnaissance' },
+    { name: 'Draft',  role: 'composition' },
+    { name: 'Verify', role: 'mechanical checks' },
+    { name: 'Record', role: 'chronicling' }
+  ]
+};
+
 function renderOrder() {
   var vc = document.getElementById('viewContainer');
   var companions = store.companions || [];
@@ -6022,18 +6042,37 @@ function renderOrderLadderSubTab(companions) {
     if (members.length > 0) html += ' <span class="cx-ladder-count">' + members.length + '</span>';
     html += '</div>';
     html += '<div class="cx-ladder-rank-occupants">';
-    if (members.length === 0) {
-      html += '<div class="cx-ladder-empty">None seated</div>';
-    } else {
+    if (members.length > 0) {
       members.forEach(function(c) { html += renderCompanionPill(c); });
+    } else if (r.key !== 'Scribe') {
+      html += '<div class="cx-ladder-empty">None seated</div>';
     }
+    // The Scribe rung is an unrostered worker tier — surface it as such
+    // rather than leaving the row reading "None seated" (canon-proc-006).
+    if (r.key === 'Scribe') html += renderScribeTierNote();
     html += '</div></div>';
   });
 
   html += '</div>';
 
-  html += '<div class="cx-ladder-footnote">Single-ladder per Constitution Book II Article 1. Military-track parallel (General/Centurion) and Treasury parallel (Collector) not yet seated.</div>';
+  html += '<div class="cx-ladder-footnote">Single-ladder per Constitution Book II Article 1. The Scribe rung is a worker tier (Article 3-bis), not a roster. Military-track parallel (General/Centurion) and Treasury parallel (Collector) not yet seated.</div>';
 
+  return html;
+}
+
+/* Renders the Scribe Worker Tier explainer on the Ladder's Scribe row.
+   The tier is constitutional structure (canon-proc-006), not roster data. */
+function renderScribeTierNote() {
+  var t = SCRIBE_TIER;
+  var html = '<div class="cx-ladder-tier">';
+  html += '<div class="cx-ladder-tier-label">Worker Tier · ' + escHtml(t.canon) + '</div>';
+  html += '<p class="cx-ladder-tier-note">' + escHtml(t.note) + '</p>';
+  html += '<div class="cx-ladder-tier-specs">';
+  t.specialisations.forEach(function(s) {
+    html += '<span class="cx-ladder-tier-spec"><strong>' + escHtml(s.name) + '</strong> '
+         +  escHtml(s.role) + '</span>';
+  });
+  html += '</div></div>';
   return html;
 }
 

--- a/split/index.html
+++ b/split/index.html
@@ -1133,6 +1133,12 @@ body {
 .cx-ladder-empty{font-size:var(--fs-xs);color:var(--text-tertiary);font-style:italic;padding:var(--sp-4) var(--sp-8)}
 .cx-ladder-seat-sovereign{font-family:var(--ff-heading);font-size:var(--fs-md);font-weight:700;color:var(--accent);padding:var(--sp-6) var(--sp-12);background:var(--bg-secondary);border-radius:var(--r-md);border:1px solid var(--accent-light);letter-spacing:0.3px}
 .cx-ladder-footnote{font-size:var(--fs-xs);color:var(--text-tertiary);font-style:italic;line-height:1.5;padding:var(--sp-8) 0;border-top:1px solid var(--border);margin-top:var(--sp-8)}
+.cx-ladder-tier{display:flex;flex-direction:column;gap:var(--sp-6);width:100%;padding:var(--sp-8) var(--sp-10);background:var(--bg-secondary);border:1px dashed var(--border);border-radius:var(--r-md)}
+.cx-ladder-tier-label{font-family:var(--ff-mono,monospace);font-size:var(--fs-2xs);color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.6px;font-weight:600}
+.cx-ladder-tier-note{font-size:var(--fs-xs);color:var(--text-secondary);line-height:1.5;margin:0}
+.cx-ladder-tier-specs{display:flex;flex-wrap:wrap;gap:var(--sp-6)}
+.cx-ladder-tier-spec{font-size:var(--fs-2xs);color:var(--text-secondary);background:var(--bg-card);border:1px solid var(--border);border-radius:var(--r-full);padding:var(--sp-2) var(--sp-8)}
+.cx-ladder-tier-spec strong{color:var(--text-primary);font-weight:700}
 
 /* ---- Companion Detail ---- */
 .cx-companion-detail-hero{background:var(--bg-card);border-radius:var(--r-lg);padding:var(--sp-20) var(--sp-16);margin-bottom:var(--sp-12);box-shadow:var(--card-shadow);border-left:3px solid var(--accent)}
@@ -5701,6 +5707,20 @@ var LADDER_RANKS = [
   { key: 'Scribe',    label: 'Scribes' }
 ];
 
+/* The Scribe rung is a worker tier, not a roster — canon-proc-006 / decree-0019,
+   Book II Article 3-bis. Like CABINET_STRUCTURE above, this is constitutional
+   structure and does not live in companions.json. */
+var SCRIBE_TIER = {
+  canon: 'canon-proc-006',
+  note: 'Each senior companion commands a detail of four task-specialised Scribes, deployed as subagents. The tier is intentionally unrostered — a rank-form, not named individuals.',
+  specialisations: [
+    { name: 'Scout',  role: 'reconnaissance' },
+    { name: 'Draft',  role: 'composition' },
+    { name: 'Verify', role: 'mechanical checks' },
+    { name: 'Record', role: 'chronicling' }
+  ]
+};
+
 function renderOrder() {
   var vc = document.getElementById('viewContainer');
   var companions = store.companions || [];
@@ -6022,18 +6042,37 @@ function renderOrderLadderSubTab(companions) {
     if (members.length > 0) html += ' <span class="cx-ladder-count">' + members.length + '</span>';
     html += '</div>';
     html += '<div class="cx-ladder-rank-occupants">';
-    if (members.length === 0) {
-      html += '<div class="cx-ladder-empty">None seated</div>';
-    } else {
+    if (members.length > 0) {
       members.forEach(function(c) { html += renderCompanionPill(c); });
+    } else if (r.key !== 'Scribe') {
+      html += '<div class="cx-ladder-empty">None seated</div>';
     }
+    // The Scribe rung is an unrostered worker tier — surface it as such
+    // rather than leaving the row reading "None seated" (canon-proc-006).
+    if (r.key === 'Scribe') html += renderScribeTierNote();
     html += '</div></div>';
   });
 
   html += '</div>';
 
-  html += '<div class="cx-ladder-footnote">Single-ladder per Constitution Book II Article 1. Military-track parallel (General/Centurion) and Treasury parallel (Collector) not yet seated.</div>';
+  html += '<div class="cx-ladder-footnote">Single-ladder per Constitution Book II Article 1. The Scribe rung is a worker tier (Article 3-bis), not a roster. Military-track parallel (General/Centurion) and Treasury parallel (Collector) not yet seated.</div>';
 
+  return html;
+}
+
+/* Renders the Scribe Worker Tier explainer on the Ladder's Scribe row.
+   The tier is constitutional structure (canon-proc-006), not roster data. */
+function renderScribeTierNote() {
+  var t = SCRIBE_TIER;
+  var html = '<div class="cx-ladder-tier">';
+  html += '<div class="cx-ladder-tier-label">Worker Tier · ' + escHtml(t.canon) + '</div>';
+  html += '<p class="cx-ladder-tier-note">' + escHtml(t.note) + '</p>';
+  html += '<div class="cx-ladder-tier-specs">';
+  t.specialisations.forEach(function(s) {
+    html += '<span class="cx-ladder-tier-spec"><strong>' + escHtml(s.name) + '</strong> '
+         +  escHtml(s.role) + '</span>';
+  });
+  html += '</div></div>';
   return html;
 }
 

--- a/split/styles.css
+++ b/split/styles.css
@@ -1072,6 +1072,12 @@ body {
 .cx-ladder-empty{font-size:var(--fs-xs);color:var(--text-tertiary);font-style:italic;padding:var(--sp-4) var(--sp-8)}
 .cx-ladder-seat-sovereign{font-family:var(--ff-heading);font-size:var(--fs-md);font-weight:700;color:var(--accent);padding:var(--sp-6) var(--sp-12);background:var(--bg-secondary);border-radius:var(--r-md);border:1px solid var(--accent-light);letter-spacing:0.3px}
 .cx-ladder-footnote{font-size:var(--fs-xs);color:var(--text-tertiary);font-style:italic;line-height:1.5;padding:var(--sp-8) 0;border-top:1px solid var(--border);margin-top:var(--sp-8)}
+.cx-ladder-tier{display:flex;flex-direction:column;gap:var(--sp-6);width:100%;padding:var(--sp-8) var(--sp-10);background:var(--bg-secondary);border:1px dashed var(--border);border-radius:var(--r-md)}
+.cx-ladder-tier-label{font-family:var(--ff-mono,monospace);font-size:var(--fs-2xs);color:var(--text-tertiary);text-transform:uppercase;letter-spacing:0.6px;font-weight:600}
+.cx-ladder-tier-note{font-size:var(--fs-xs);color:var(--text-secondary);line-height:1.5;margin:0}
+.cx-ladder-tier-specs{display:flex;flex-wrap:wrap;gap:var(--sp-6)}
+.cx-ladder-tier-spec{font-size:var(--fs-2xs);color:var(--text-secondary);background:var(--bg-card);border:1px solid var(--border);border-radius:var(--r-full);padding:var(--sp-2) var(--sp-8)}
+.cx-ladder-tier-spec strong{color:var(--text-primary);font-weight:700}
 
 /* ---- Companion Detail ---- */
 .cx-companion-detail-hero{background:var(--bg-card);border-radius:var(--r-lg);padding:var(--sp-20) var(--sp-16);margin-bottom:var(--sp-12);box-shadow:var(--card-shadow);border-left:3px solid var(--accent)}

--- a/split/views.js
+++ b/split/views.js
@@ -2936,6 +2936,20 @@ var LADDER_RANKS = [
   { key: 'Scribe',    label: 'Scribes' }
 ];
 
+/* The Scribe rung is a worker tier, not a roster — canon-proc-006 / decree-0019,
+   Book II Article 3-bis. Like CABINET_STRUCTURE above, this is constitutional
+   structure and does not live in companions.json. */
+var SCRIBE_TIER = {
+  canon: 'canon-proc-006',
+  note: 'Each senior companion commands a detail of four task-specialised Scribes, deployed as subagents. The tier is intentionally unrostered — a rank-form, not named individuals.',
+  specialisations: [
+    { name: 'Scout',  role: 'reconnaissance' },
+    { name: 'Draft',  role: 'composition' },
+    { name: 'Verify', role: 'mechanical checks' },
+    { name: 'Record', role: 'chronicling' }
+  ]
+};
+
 function renderOrder() {
   var vc = document.getElementById('viewContainer');
   var companions = store.companions || [];
@@ -3257,18 +3271,37 @@ function renderOrderLadderSubTab(companions) {
     if (members.length > 0) html += ' <span class="cx-ladder-count">' + members.length + '</span>';
     html += '</div>';
     html += '<div class="cx-ladder-rank-occupants">';
-    if (members.length === 0) {
-      html += '<div class="cx-ladder-empty">None seated</div>';
-    } else {
+    if (members.length > 0) {
       members.forEach(function(c) { html += renderCompanionPill(c); });
+    } else if (r.key !== 'Scribe') {
+      html += '<div class="cx-ladder-empty">None seated</div>';
     }
+    // The Scribe rung is an unrostered worker tier — surface it as such
+    // rather than leaving the row reading "None seated" (canon-proc-006).
+    if (r.key === 'Scribe') html += renderScribeTierNote();
     html += '</div></div>';
   });
 
   html += '</div>';
 
-  html += '<div class="cx-ladder-footnote">Single-ladder per Constitution Book II Article 1. Military-track parallel (General/Centurion) and Treasury parallel (Collector) not yet seated.</div>';
+  html += '<div class="cx-ladder-footnote">Single-ladder per Constitution Book II Article 1. The Scribe rung is a worker tier (Article 3-bis), not a roster. Military-track parallel (General/Centurion) and Treasury parallel (Collector) not yet seated.</div>';
 
+  return html;
+}
+
+/* Renders the Scribe Worker Tier explainer on the Ladder's Scribe row.
+   The tier is constitutional structure (canon-proc-006), not roster data. */
+function renderScribeTierNote() {
+  var t = SCRIBE_TIER;
+  var html = '<div class="cx-ladder-tier">';
+  html += '<div class="cx-ladder-tier-label">Worker Tier · ' + escHtml(t.canon) + '</div>';
+  html += '<p class="cx-ladder-tier-note">' + escHtml(t.note) + '</p>';
+  html += '<div class="cx-ladder-tier-specs">';
+  t.specialisations.forEach(function(s) {
+    html += '<span class="cx-ladder-tier-spec"><strong>' + escHtml(s.name) + '</strong> '
+         +  escHtml(s.role) + '</span>';
+  });
+  html += '</div></div>';
   return html;
 }
 


### PR DESCRIPTION
## Summary
Clears the follow-on from the Scribe Worker Tier integration (#75): the Codex Order view's **Ladder sub-tab** rendered the Scribe row as *"None seated"*, which read as a vacancy. The rung is an **unrostered worker tier** by design (canon-proc-006) — it now says so.

- The Scribe row now renders a worker-tier explainer instead of "None seated": the four task-specialised Scribes (Scout · Draft · Verify · Record) as chips, plus a note that the tier is intentionally unrostered.
- `SCRIBE_TIER` is a hardcoded constant — constitutional structure, mirroring the existing `CABINET_STRUCTURE` (neither lives in `companions.json`).
- Ladder footnote updated to name Article 3-bis.
- If a named companion is ever seated at Scribe rank, its pill renders above the tier note as normal.

Investigated by Aurelius; built by Orinth (Codex Builder, `split/*.js` authority).

## Test plan
- [x] `node --check` passes on `views.js` / `start.js`
- [x] `renderScribeTierNote()` render test — valid escaped HTML, all 4 specs, canon cited
- [x] `bash build.sh` succeeds; built HTML carries the new code; HTML diff == `views.js` + `styles.css` only
- [x] CSS uses only existing design-system variables
- [ ] Visual browser check — **not done**: no headless browser in this environment. Verification was syntax + render-test + build, not a rendered page.

https://claude.ai/code/session_018DJBhuhqc6KASxa2h8n8X5

---
_Generated by [Claude Code](https://claude.ai/code/session_018DJBhuhqc6KASxa2h8n8X5)_