### PR TITLE
Codex design-principles audit (Orinth first-act): fix HR-C-06, green the suite

### DIFF
--- a/docs/specs/CODEX_DESIGN_PRINCIPLES.md
+++ b/docs/specs/CODEX_DESIGN_PRINCIPLES.md
@@ -1,6 +1,6 @@
 # CODEX_DESIGN_PRINCIPLES.md — Draft v0.1
 
-**Status:** draft (pending codification, audit of existing tabs, ratification)
+**Status:** draft — codebase audit completed 2026-05-22 (Orinth, first operational act per canon-proc-002; see §11). Pending: the visual tab walk (needs the Sovereign's device per §8.2) and Sovereign ratification.
 **Scope:** Codex PWA visual + interaction discipline. Extends and adapts the Republic-wide principles that originated in SproutLab's `docs/chapters/ch06-designprinciples.json` (the Hard Rules HR-1..HR-12). Codex-specific rules are numbered `HR-C-*` to keep the namespaces distinct.
 **Workflow:** draft → codify (this document) → audit existing tabs for compliance → ratify as Codex's constitution → extract a `REPUBLIC_DESIGN_PRINCIPLES.md` for the universal subset.
 
@@ -153,15 +153,24 @@ Sections of this document that should be promoted into `REPUBLIC_DESIGN_PRINCIPL
 
 Before this document ratifies, a single-session audit should:
 
-- [ ] Grep `references.*\.join` → expect zero matches (HR-C-06).
-- [ ] Grep `style="` in `split/views.js` + `split/forms.js` → audit every match; most should be HR-2 waivers (data-driven color) and nothing else.
-- [ ] Grep `onclick=|onchange=` → expect zero (HR-3).
-- [ ] Walk every tab visually in both light and dark mode, with filters at default and with filters applied. Capture screenshots for the audit chronicle.
-- [ ] Confirm every card variant carries category color treatment where §3.4 specifies one. The Canons polish commit is the precedent — no entity-type card should ship without the left-border + filled chip treatment when a primary classification exists.
-- [ ] Run `npx playwright test` — all cases green.
-- [ ] Read CLAUDE.md and confirm the design-principles reference is wired in.
+- [x] Grep `references.*\.join` → **1 genuine violation found and fixed.** `views.js` canon-detail view rendered references as `escHtml(canon.references.join(', '))` — the exact anti-pattern §7.1 names. The canon *card* already used `renderReferenceLink()`; the *detail* view was the sibling site the Canons polish missed. Fixed 2026-05-22. The 3 remaining `.join` matches are not violations: `forms.js` ×2 are form-input pre-fill (editing references as a comma-separated text field), `forms.js` ×1 is markdown-export string assembly — neither is a UI render site.
+- [~] Grep `style="` in `split/views.js` + `split/forms.js` → **115 occurrences** (views 89, forms 26). Spot-checks confirm the bulk are data-driven color waivers (§1.1) and layout one-offs (`margin:0`). A full match-by-match classification into {HR-2 waiver, layout one-off needing a token/class, genuine violation} is owed before ratification — sized as its own sub-audit.
+- [x] Grep `onclick=|onchange=` → **0 actual inline handlers** (HR-3 PASS). The single grep hit is canon rationale *text* in `seed.js` describing the rule itself, not a handler.
+- [ ] Walk every tab visually in both light and dark mode, with filters at default and with filters applied. Capture screenshots for the audit chronicle. **Owed — needs the Sovereign's device per §8.2.**
+- [ ] Confirm every card variant carries category color treatment where §3.4 specifies one. The Canons polish commit is the precedent — no entity-type card should ship without the left-border + filled chip treatment when a primary classification exists. **Owed — folds into the visual walk.**
+- [x] Run `npx playwright test` → **90 cases green.** The audit found 4 stale assertions in `order-view.spec.js` (companion count 18→19 post-CodeMike/canon-inst-005; cabinet vacancies 2→3 post-canon-inst-002; the Scribes Ladder row post-canon-proc-006; Orinth's profile chip stub→v0.4-draft). The app behaviour was correct in all four — the tests lagged ratified canon. Tests reconciled 2026-05-22.
+- [x] Read CLAUDE.md and confirm the design-principles reference is wired in → present in the Codex App §Open/pending block.
 
 Audit findings become amendments to the draft before ratification. Post-ratification, this document's discipline is the baseline for every new feature.
+
+### 11.1 Audit log — 2026-05-22 (Orinth, first-act per canon-proc-002)
+
+The mechanical sweep is complete; the visual layer is not. State for the Sovereign:
+
+- **Ready to ratify on:** the Hard-Rule code disciplines (HR-3, HR-C-06) — swept, one violation found and corrected, suite green.
+- **Owed before ratification:** (a) the full `style="` classification pass; (b) the visual tab walk, light + dark, which §8.2 names as un-automatable and device-bound.
+- **Recommended amendment (not yet applied):** §0–§11 are assembled out of numerical order in the file (the reading order runs 0,1,8,9,10,11,6,7,5,4,3,2). A pure-reorder pass is recommended once the substantive audit closes, kept as its own commit so the diff stays reviewable.
+- **Not build-gating yet:** per canon-proc-002 the Codex design-principles chip stays `draft` until ratification; new Codex-surface build remains gated on the chip turning green.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -3913,10 +3913,17 @@ function renderCanonDetail(route) {
     html += '<div class="cx-card"><div class="cx-card-body" style="margin:0;line-height:1.6">' + escHtml(canon.rationale) + '</div></div>';
   }
 
-  // References
+  // References — resolved via renderReferenceLink per HR-C-06 / canon-0052
+  // §Cross-Cutting Discipline. The canon card at the list level already does
+  // this; the detail view was the sibling site the Canons polish missed.
   if (canon.references && canon.references.length > 0) {
     html += '<div class="cx-section-title">References</div>';
-    html += '<div class="cx-card"><div class="cx-card-body" style="margin:0">' + escHtml(canon.references.join(', ')) + '</div></div>';
+    html += '<div class="cx-card"><div class="cx-card-body" style="margin:0">';
+    canon.references.forEach(function(refId, idx) {
+      if (idx > 0) html += ', ';
+      html += renderReferenceLink(refId);
+    });
+    html += '</div></div>';
   }
 
   // Supersession Chain

--- a/split/codex.html
+++ b/split/codex.html
@@ -3913,10 +3913,17 @@ function renderCanonDetail(route) {
     html += '<div class="cx-card"><div class="cx-card-body" style="margin:0;line-height:1.6">' + escHtml(canon.rationale) + '</div></div>';
   }
 
-  // References
+  // References — resolved via renderReferenceLink per HR-C-06 / canon-0052
+  // §Cross-Cutting Discipline. The canon card at the list level already does
+  // this; the detail view was the sibling site the Canons polish missed.
   if (canon.references && canon.references.length > 0) {
     html += '<div class="cx-section-title">References</div>';
-    html += '<div class="cx-card"><div class="cx-card-body" style="margin:0">' + escHtml(canon.references.join(', ')) + '</div></div>';
+    html += '<div class="cx-card"><div class="cx-card-body" style="margin:0">';
+    canon.references.forEach(function(refId, idx) {
+      if (idx > 0) html += ', ';
+      html += renderReferenceLink(refId);
+    });
+    html += '</div></div>';
   }
 
   // Supersession Chain

--- a/split/index.html
+++ b/split/index.html
@@ -3913,10 +3913,17 @@ function renderCanonDetail(route) {
     html += '<div class="cx-card"><div class="cx-card-body" style="margin:0;line-height:1.6">' + escHtml(canon.rationale) + '</div></div>';
   }
 
-  // References
+  // References — resolved via renderReferenceLink per HR-C-06 / canon-0052
+  // §Cross-Cutting Discipline. The canon card at the list level already does
+  // this; the detail view was the sibling site the Canons polish missed.
   if (canon.references && canon.references.length > 0) {
     html += '<div class="cx-section-title">References</div>';
-    html += '<div class="cx-card"><div class="cx-card-body" style="margin:0">' + escHtml(canon.references.join(', ')) + '</div></div>';
+    html += '<div class="cx-card"><div class="cx-card-body" style="margin:0">';
+    canon.references.forEach(function(refId, idx) {
+      if (idx > 0) html += ', ';
+      html += renderReferenceLink(refId);
+    });
+    html += '</div></div>';
   }
 
   // Supersession Chain

--- a/split/views.js
+++ b/split/views.js
@@ -1142,10 +1142,17 @@ function renderCanonDetail(route) {
     html += '<div class="cx-card"><div class="cx-card-body" style="margin:0;line-height:1.6">' + escHtml(canon.rationale) + '</div></div>';
   }
 
-  // References
+  // References — resolved via renderReferenceLink per HR-C-06 / canon-0052
+  // §Cross-Cutting Discipline. The canon card at the list level already does
+  // this; the detail view was the sibling site the Canons polish missed.
   if (canon.references && canon.references.length > 0) {
     html += '<div class="cx-section-title">References</div>';
-    html += '<div class="cx-card"><div class="cx-card-body" style="margin:0">' + escHtml(canon.references.join(', ')) + '</div></div>';
+    html += '<div class="cx-card"><div class="cx-card-body" style="margin:0">';
+    canon.references.forEach(function(refId, idx) {
+      if (idx > 0) html += ', ';
+      html += renderReferenceLink(refId);
+    });
+    html += '</div></div>';
   }
 
   // Supersession Chain

--- a/tests/order-view.spec.js
+++ b/tests/order-view.spec.js
@@ -42,7 +42,7 @@ async function waitForBoot(page) {
 test.describe('The Order — mobile smoke', () => {
   test.beforeEach(async ({ page }) => { await seedAppData(page); });
 
-  test('Order tab is reachable, Roster renders 18 companions', async ({ page }) => {
+  test('Order tab is reachable, Roster renders 19 companions', async ({ page }) => {
     await page.goto('/index.html');
     await waitForBoot(page);
 
@@ -50,21 +50,22 @@ test.describe('The Order — mobile smoke', () => {
     await page.locator('[data-action="switchTab"][data-tab="order"]').click();
     await expect(page).toHaveURL(/#\/order/);
 
-    // Hero title + stats.
+    // Hero title + stats. 19 total = 18 generational + 1 institutional
+    // (CodeMike is the 19th, first Gen 1, seated per canon-inst-005).
     await expect(page.locator('.cx-page-title')).toContainText('The Order');
     const stats = page.locator('.cx-order-stat-value');
-    await expect(stats.nth(0)).toHaveText('18');
-    await expect(stats.nth(1)).toHaveText('17');
+    await expect(stats.nth(0)).toHaveText('19');
+    await expect(stats.nth(1)).toHaveText('18');
     await expect(stats.nth(2)).toHaveText('1');
 
-    // All 18 companions present as cards (match on companion-card title).
-    const names = ['Aurelius','Cipher','Consul','Ashara','Petra','Lyra','Maren','Kael','Nyx','Solara','Theron','Vex','Orinth','Rune','Ignis','Bard','Aeon','Pip'];
+    // All 19 companions present as cards (match on companion-card title).
+    const names = ['Aurelius','Cipher','Consul','Ashara','Petra','Lyra','Maren','Kael','Nyx','Solara','Theron','Vex','Orinth','Rune','Ignis','Bard','Aeon','Pip','CodeMike'];
     for (const name of names) {
       await expect(page.locator('.cx-companion-card').filter({ hasText: name }).first()).toBeVisible();
     }
   });
 
-  test('Cabinet subtab: 7 of 8 seats filled, Debt vacant', async ({ page }) => {
+  test('Cabinet subtab: 5 of 8 seats filled, three vacancies', async ({ page }) => {
     await page.goto('/index.html#/order');
     await waitForBoot(page);
 
@@ -75,14 +76,14 @@ test.describe('The Order — mobile smoke', () => {
       await expect(page.locator('.cx-cabinet-domain-title').filter({ hasText: domain })).toBeVisible();
     }
 
-    // Two vacancies after canon-inst-001 (Debt per cc-011, Expansion per inst-001).
+    // Three vacancies: Debt (canon-cc-011), Stability (canon-inst-002 — Rune
+    // elevated to Priest), Expansion (canon-inst-001 — Orinth to Codex Builder).
     const vacant = page.locator('.cx-cabinet-seat-vacant');
-    await expect(vacant).toHaveCount(2);
+    await expect(vacant).toHaveCount(3);
 
     // Occupants landed on their expected portfolios.
     await expect(page.locator('.cx-cabinet-seat').filter({ hasText: 'Treasury' }).filter({ hasText: 'Ashara' })).toBeVisible();
     await expect(page.locator('.cx-cabinet-seat').filter({ hasText: 'Efficiency' }).filter({ hasText: 'Petra' })).toBeVisible();
-    await expect(page.locator('.cx-cabinet-seat').filter({ hasText: 'Stability' }).filter({ hasText: 'Rune' })).toBeVisible();
     await expect(page.locator('.cx-cabinet-seat').filter({ hasText: 'Innovation' }).filter({ hasText: 'Bard' })).toBeVisible();
   });
 
@@ -103,7 +104,7 @@ test.describe('The Order — mobile smoke', () => {
     }
   });
 
-  test('Ladder subtab: Sovereign → Scribes with empty state', async ({ page }) => {
+  test('Ladder subtab: Sovereign → Scribes Worker Tier row', async ({ page }) => {
     await page.goto('/index.html#/order');
     await waitForBoot(page);
     await page.locator('[data-action="setSubTab"][data-tab="order"][data-key="ladder"]').click();
@@ -112,7 +113,9 @@ test.describe('The Order — mobile smoke', () => {
     for (const rank of ['Consul', 'Censors', 'Builders', 'Governors']) {
       await expect(page.locator('.cx-ladder-row').filter({ hasText: rank })).toBeVisible();
     }
-    await expect(page.locator('.cx-ladder-row').filter({ hasText: 'Scribes' })).toContainText(/None seated/i);
+    // The Scribes row surfaces the Worker Tier (canon-proc-006) — an unrostered
+    // rank-form, not named individuals.
+    await expect(page.locator('.cx-ladder-row').filter({ hasText: 'Scribes' })).toContainText(/Worker Tier/i);
   });
 
   test('Companion detail: Aurelius card → detail page renders Voice/Mind/Shadow blocks, no raw JSON', async ({ page }) => {
@@ -135,19 +138,23 @@ test.describe('The Order — mobile smoke', () => {
     await expect(page).toHaveURL(/#\/order/);
   });
 
-  test('Stub companion (Orinth): detail renders identity + assignment, no pre dumps', async ({ page }) => {
+  test('Orinth detail: v0.4-draft profile renders Voice/Mind/Shadow blocks, no raw JSON', async ({ page }) => {
     await page.goto('/index.html#/companion/orinth');
     await waitForBoot(page);
 
     await expect(page.locator('.cx-page-title')).toContainText('Orinth');
     await expect(page.locator('.cx-companion-block-title').filter({ hasText: 'Assignment' })).toBeVisible();
 
-    // Stubs don't populate voice/mind/shadow blocks — verify they're absent
-    // rather than empty-rendered with debug dumps.
+    // Orinth was lifted from v0.0-stub to a full v0.4-draft profile when his
+    // canon-proc-003 onboarding completed — the voice/mind/shadow blocks now
+    // render, and no block is an empty-rendered debug dump.
+    await expect(page.locator('.cx-companion-block-title').filter({ hasText: 'Voice' })).toBeVisible();
+    await expect(page.locator('.cx-companion-block-title').filter({ hasText: 'Mind' })).toBeVisible();
+    await expect(page.locator('.cx-companion-block-title').filter({ hasText: 'Shadow' })).toBeVisible();
     await expect(page.locator('.cx-companion-pre')).toHaveCount(0);
 
-    // Stub profile-version chip.
-    await expect(page.locator('.cx-chip-version-draft, .cx-chip-version-stub').filter({ hasText: /stub|0\.0/ })).toBeVisible();
+    // Profile-version chip reads v0.4-draft.
+    await expect(page.locator('.cx-chip-version-draft, .cx-chip-version-stub').filter({ hasText: /0\.4|draft/ })).toBeVisible();
   });
 
   test('Design-principles chip renders on Volume cards (canon-proc-002)', async ({ page }) => {


### PR DESCRIPTION
## Summary

Orinth's first operational act as Codex Builder — the codebase audit pass toward ratifying `CODEX_DESIGN_PRINCIPLES.md` (canon-proc-002 first-act discipline). Mechanical sweep done; the visual layer is device-bound and still owed.

## Findings & fixes

**HR-C-06 — one genuine violation, fixed.** The canon *detail* view rendered references as `escHtml(canon.references.join(', '))` — the exact anti-pattern §7.1 names. The canon *card* already used `renderReferenceLink()`; the detail view was the sibling site the Canons polish missed. Now resolves each reference to a clickable navigate button. Rebuilt via `build.sh`. The 3 other `.join` hits are form-input pre-fill and markdown-export — not UI render sites, not violations.

**HR-3 — clean.** Zero inline `onclick=`/`onchange=` handlers. (The one grep hit is canon rationale *text* in `seed.js`.)

**Playwright — 90 green** (was 82, 8 red). The 8 failures were 4 stale assertions in `order-view.spec.js`, each lagging ratified canon:
| Test | Stale because | App was |
|------|---------------|---------|
| Roster count 18 | CodeMike seated 19th (canon-inst-005) | correct (19) |
| Cabinet 2 vacant | Rune vacated Stability (canon-inst-002) | correct (3) |
| Scribes "None seated" | Scribe Worker Tier surfaced on Ladder (canon-proc-006, PR #76) | correct |
| Orinth stub chip | profile lifted to v0.4-draft (PR #77) | correct |

App behaviour was right in all four — the tests were reconciled, not the app.

## Still owed before ratification

- The visual tab walk (light + dark) — §8.2 names this un-automatable and device-bound; needs the Sovereign.
- A full `style="` classification pass (115 occurrences across views/forms).
- Recommended (separate commit): reorder §0–§11, currently assembled out of numerical order.

`CODEX_DESIGN_PRINCIPLES.md` §11 records all of this. The design-principles chip stays `draft`; new Codex-surface build remains gated until ratification.

## Test plan

- [x] `cd split && bash build.sh` — clean rebuild
- [x] `npx playwright test` — 90 passed
- [x] `grep references.*\.join split/*.js` — no UI-render violations remain
- [ ] Visual tab walk (Sovereign device)
- [ ] Sovereign ratification of the design-principles draft

https://claude.ai/code/session_014zw5vopEq4yKmTmrbLyEob

---
_Generated by [Claude Code](https://claude.ai/code/session_014zw5vopEq4yKmTmrbLyEob)_