### PR TITLE
docs(skills): promote /sproutlab-compact canonical body to Codex

### DIFF
--- a/docs/specs/skills/sproutlab-compact.md
+++ b/docs/specs/skills/sproutlab-compact.md
@@ -1,0 +1,35 @@
+<!-- CANONICAL BODY (Province-local). Pending promotion to Codex docs/specs/skills/
+     per canon-cc-026; canon-cc-026 mirror then replicates to .claude/skills/.
+     This tracked copy is the durable source until a Codex-scoped session lifts it. -->
+
+---
+name: sproutlab-compact
+description: Prepare a SproutLab session for /compact. Use BEFORE running /compact on a long SproutLab build session — it writes a graph-anchored, ephemeral resume handoff so post-compact work starts exactly where it left off (PR/branch state, next action, the canon-cc-008 summon-set, and file→symbol anchors). Trigger on "/sproutlab-compact", "prep for compact", "write a handoff before compacting".
+---
+
+# /sproutlab-compact — pre-compaction ritual
+
+Stock `/compact` summarizes the transcript but loses navigation precision and the resume plan. This skill produces a durable-on-disk, graph-anchored handoff that survives compaction, then hands control back to `/compact`.
+
+## Run these steps, in order
+
+1. **Refresh the code graph** (so anchors/routing are current — skip if you just built):
+   `pnpm graph` *(or `SKIP_GRAPH=1` was set; then run `pnpm graph` explicitly)*
+
+2. **Compute the QA summon-set** for the in-flight diff (graph-derived ripple):
+   `pnpm qa-route` — capture the SUMMON list (Maren/Kael/Vela + shared-file triple-Gov).
+
+3. **Write the ephemeral handoff** to `/tmp/sproutlab-<feature>-handoff.md`. It MUST contain:
+   - **Where we are**: branch, PR # + draft state, preview URL, one-line feature status.
+   - **NEXT ACTION**: the single next step (e.g. Stage-3 canon-cc-008 gate) + the `qa-route` summon-set + who is BLOCKING.
+   - **Key anchors**: `file → symbol` map for every symbol the feature touches (pull from the graph / `graphify query` if unsure). Prefer symbol names over line numbers (lines drift).
+   - **Resolved-don't-relitigate**: any hard-won fixes (with the root cause) so post-compact-you doesn't redo them.
+   - **NOT in this PR**: deferred/out-of-scope items.
+   - **Build/commit**: `pnpm build` → commit → push; note PR-event webhooks are mostly Vercel Building/Ready (no action).
+
+4. **Tell the Architect**: handoff is written at the path; **run `/compact` now**; and that the **first post-compact action is to read that file** + `git log --oneline -8`.
+
+## Notes
+- The handoff is **ephemeral** (`/tmp/`, not committed) — it's a scratch resume aid, not a Codex record. For a durable session record, summon the **Chronicler** (Aurelius) instead.
+- Keep the handoff tight (~1 screen). It's a launchpad, not a transcript.
+- This skill is a **convenience ritual**, not a canon gate; it does not discharge canon-cc-008.


### PR DESCRIPTION
Copies SproutLab's `docs/specs/skills/sproutlab-compact.md` into Codex `docs/specs/skills/`, the canon-cc-026 promotion of the Province-local canonical body to its Codex-scoped canonical home (alongside chronicler/cipher/kael/lyra/maren/vela).

The source file was just landed on sproutlab `main` via PR #224; this is a byte-identical copy.

https://claude.ai/code/session_014BaXNwyxLJt9p42L5vy39W

---
_Generated by [Claude Code](https://claude.ai/code/session_014BaXNwyxLJt9p42L5vy39W)_