### PR TITLE
docs(specs): mark sproutlab-compact deploy gap closed

### DIFF
--- a/docs/specs/skills/sproutlab-compact.md
+++ b/docs/specs/skills/sproutlab-compact.md
@@ -2,8 +2,8 @@
      Promoted to the Codex docs/specs/skills/ canonical home 2026-06-04 (PR #85).
      Province-local utility skill — single-Province deployment. Deploys byte-identical
      to sproutlab/.claude/skills/sproutlab-compact.md per canon-cc-026 §Per-Province-Layout.
-     DEPLOY GAP (open): the SproutLab mirror at .claude/skills/sproutlab-compact.md is not
-     yet present; a SproutLab-scoped session must drop this byte-identical to close it.
+     DEPLOY: the SproutLab mirror at .claude/skills/sproutlab-compact.md was deployed
+     byte-identical 2026-06-05, closing the prior deploy gap.
      Amendment path: canon-cc-027 signing chain. -->
 
 ---


### PR DESCRIPTION
Companion to the SproutLab redeploy. The SproutLab mirror at `.claude/skills/sproutlab-compact.md` has now been deployed byte-identical, so the canon provenance comment's `DEPLOY GAP (open)` note in `docs/specs/skills/sproutlab-compact.md` is updated to record the closed gap (deployed 2026-06-05).

Keeps the canon and the Province mirror byte-identical and the provenance note truthful. Comment-only — the skill body is unchanged.

https://claude.ai/code/session_011C34ei6PorU5gme7NYN2xF

---
_Generated by [Claude Code](https://claude.ai/code/session_011C34ei6PorU5gme7NYN2xF)_