### PR TITLE
World Cup dashboard: live scores via API-Football serverless feed

### DIFF
--- a/library/world-cup-2026/README.md
+++ b/library/world-cup-2026/README.md
@@ -38,6 +38,27 @@ library/world-cup-2026/
   toast if permission is denied). Preference persists in localStorage.
 - **Installable PWA** — `manifest.webmanifest` + `sw.js` make it installable to a home screen and
   usable offline; the install button appears when the browser offers it.
+- **Live scores (optional)** — a Vercel serverless function (`api/scores.js`) proxies live World Cup
+  scores from API-Football, and the client polls it (~45s) to auto-update the bracket, match board and
+  live strip with real scores + match minute, showing a "LIVE DATA · updated …" badge. Degrades
+  gracefully to the curated snapshot when the feed is unavailable.
+
+## Enabling live scores
+
+The live feed is **off until an API key is configured** (the page still works fully on the curated
+snapshot without it). To turn it on:
+
+1. Get a free API key at **https://www.api-sports.io/** (issued instantly).
+2. In Vercel → project **codex** → **Settings → Environment Variables**, add
+   `FOOTBALL_API_KEY` = your key (Production + Preview), then redeploy.
+
+**How it stays within the free tier (100 req/day):** `api/scores.js` only calls API-Football when a
+fixture is actually inside its live window, and sets `Cache-Control: s-maxage` so Vercel's CDN serves
+most page polls from cache — the upstream API is hit at most ~once every 120s while a match is live,
+and **zero** times when nothing is live. On any error / missing key / rate-limit the function returns
+`{source:'stale'}` and the client keeps the snapshot, so the page never breaks. The key lives only in
+the Vercel environment — it is never shipped to the browser. Heavy match days may approach the daily
+cap; api-sports' cheap paid tiers remove it if bulletproof coverage is wanted.
 
 ## The dashboard (`index.html`)
 

--- a/library/world-cup-2026/api/scores.js
+++ b/library/world-cup-2026/api/scores.js
@@ -1,0 +1,116 @@
+// Vercel serverless function — live World Cup 2026 scores via API-Football (api-sports.io).
+//
+// Design goals:
+//  - Secret key stays server-side (process.env.FOOTBALL_API_KEY); never shipped to the client.
+//  - Respect the 100 req/day free tier: only call upstream when a fixture is actually in its live
+//    window, and let Vercel's CDN cache the response (s-maxage) so many users => few upstream calls.
+//  - Never break the page: any error / missing key / rate-limit => { source:'stale', matches:[] }
+//    and the client keeps its curated snapshot.
+
+const API_BASE = 'https://v3.football.api-sports.io';
+const WC_LEAGUE = 1;
+const WC_SEASON = 2026;
+const PLAY_MS = 150 * 60 * 1000; // ~2.5h live window (covers ET + penalties)
+
+// Baked-in fixture schedule — kept in sync with the client MATCHES (kickoff ISO + our flag codes).
+// Used to (a) gate upstream calls to live windows and (b) match API fixtures to our board.
+const FIXTURES = [
+  ['2026-06-29T00:30:00+05:30', 'za', 'ca'],
+  ['2026-06-29T22:30:00+05:30', 'br', 'jp'],
+  ['2026-06-30T02:00:00+05:30', 'de', 'py'],
+  ['2026-06-30T06:30:00+05:30', 'nl', 'ma'],
+  ['2026-06-30T22:30:00+05:30', 'ci', 'no'],
+  ['2026-07-01T02:30:00+05:30', 'fr', 'se'],
+  ['2026-07-01T06:30:00+05:30', 'mx', 'ec'],
+  ['2026-07-01T21:30:00+05:30', 'gb-eng', 'cd'],
+  ['2026-07-02T01:30:00+05:30', 'be', 'sn'],
+  ['2026-07-02T05:30:00+05:30', 'us', 'ba'],
+  ['2026-07-03T00:30:00+05:30', 'es', 'at'],
+  ['2026-07-03T04:30:00+05:30', 'pt', 'hr'],
+  ['2026-07-03T08:30:00+05:30', 'ch', 'dz'],
+  ['2026-07-03T23:30:00+05:30', 'au', 'eg'],
+  ['2026-07-04T03:30:00+05:30', 'ar', 'cv'],
+  ['2026-07-04T07:00:00+05:30', 'co', 'gh'],
+];
+
+// API-Football team name (lowercased) -> our flag code. Includes common aliases.
+const NAME2CODE = {
+  'south africa': 'za', 'canada': 'ca', 'brazil': 'br', 'japan': 'jp', 'germany': 'de',
+  'paraguay': 'py', 'netherlands': 'nl', 'morocco': 'ma', 'ivory coast': 'ci', "cote d'ivoire": 'ci',
+  'norway': 'no', 'france': 'fr', 'sweden': 'se', 'mexico': 'mx',
+  'ecuador': 'ec', 'england': 'gb-eng', 'dr congo': 'cd', 'congo dr': 'cd', 'democratic republic of congo': 'cd',
+  'belgium': 'be', 'senegal': 'sn', 'usa': 'us', 'united states': 'us', 'bosnia and herzegovina': 'ba',
+  'spain': 'es', 'austria': 'at', 'portugal': 'pt', 'croatia': 'hr', 'switzerland': 'ch',
+  'algeria': 'dz', 'australia': 'au', 'egypt': 'eg', 'argentina': 'ar', 'cape verde': 'cv',
+  'colombia': 'co', 'ghana': 'gh',
+};
+const code = name => NAME2CODE[String(name || '').trim().toLowerCase()] || null;
+
+const LIVE_STATUSES = new Set(['1H', '2H', 'HT', 'ET', 'BT', 'P', 'LIVE', 'INT', 'SUSP']);
+const FINAL_STATUSES = new Set(['FT', 'AET', 'PEN']);
+function mapStatus(short) {
+  if (FINAL_STATUSES.has(short)) return 'final';
+  if (LIVE_STATUSES.has(short)) return 'live';
+  return 'sched';
+}
+
+// IST date (YYYY-MM-DD) for a given epoch — used for the date query param.
+function istDate(ms) {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Kolkata', year: 'numeric', month: '2-digit', day: '2-digit',
+  }).format(new Date(ms));
+}
+
+module.exports = async (req, res) => {
+  const now = Date.now();
+  // Which fixture (if any) is currently inside its live window?
+  const liveFix = FIXTURES.find(([t]) => {
+    const ko = new Date(t).getTime();
+    return now >= ko && now < ko + PLAY_MS;
+  });
+
+  // CDN cache: short while live, longer when idle (cuts upstream calls hard on the free tier).
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Cache-Control',
+    liveFix ? 's-maxage=120, stale-while-revalidate=300' : 's-maxage=900, stale-while-revalidate=1800');
+
+  // No live match right now -> no upstream call; client keeps the snapshot.
+  if (!liveFix) {
+    return res.status(200).end(JSON.stringify({ source: 'snapshot', live: false, updated: new Date(now).toISOString(), matches: [] }));
+  }
+
+  const key = process.env.FOOTBALL_API_KEY;
+  if (!key) {
+    return res.status(200).end(JSON.stringify({ source: 'stale', reason: 'no-key', live: true, matches: [] }));
+  }
+
+  try {
+    const date = istDate(new Date(liveFix[0]).getTime());
+    const url = `${API_BASE}/fixtures?league=${WC_LEAGUE}&season=${WC_SEASON}&date=${date}&timezone=Asia/Kolkata`;
+    const r = await fetch(url, { headers: { 'x-apisports-key': key } });
+    if (!r.ok) {
+      return res.status(200).end(JSON.stringify({ source: 'stale', reason: `http-${r.status}`, live: true, matches: [] }));
+    }
+    const data = await r.json();
+    const matches = (data.response || []).map(f => {
+      const a = code(f.teams && f.teams.home && f.teams.home.name);
+      const b = code(f.teams && f.teams.away && f.teams.away.name);
+      if (!a || !b) return null; // unmapped team -> skip, snapshot retained for that tie
+      const pen = f.score && f.score.penalty;
+      const hasPen = pen && (pen.home != null || pen.away != null);
+      const st = f.fixture && f.fixture.status;
+      return {
+        key: `${a}|${b}`, a, b,
+        scoreA: f.goals && f.goals.home, scoreB: f.goals && f.goals.away,
+        status: mapStatus(st && st.short),
+        minute: (st && st.elapsed != null) ? st.elapsed : null,
+        pens: hasPen ? `${pen.home}–${pen.away}` : null,
+        winner: (f.teams && f.teams.home && f.teams.home.winner) ? 'a'
+              : (f.teams && f.teams.away && f.teams.away.winner) ? 'b' : null,
+      };
+    }).filter(Boolean);
+    return res.status(200).end(JSON.stringify({ source: 'api', live: true, updated: new Date(now).toISOString(), matches }));
+  } catch (e) {
+    return res.status(200).end(JSON.stringify({ source: 'stale', reason: 'fetch-error', live: true, matches: [] }));
+  }
+};

--- a/library/world-cup-2026/index.html
+++ b/library/world-cup-2026/index.html
@@ -218,6 +218,13 @@ footer .srcs a{display:block;margin-bottom:var(--sp-6);color:var(--accent);text-
 footer .srcs a:hover{text-decoration:underline}
 .note{font-size:var(--fs-xs);color:var(--faint);margin-top:var(--sp-16);line-height:var(--lh-relaxed)}
 
+/* ============ Live feed badge ============ */
+#feedbadge{display:none;font-size:var(--fs-2xs);font-weight:700;letter-spacing:.04em;color:var(--c-final);
+  background:color-mix(in srgb,var(--c-final) 14%,transparent);border:1px solid color-mix(in srgb,var(--c-final) 40%,transparent);
+  padding:2px 9px;border-radius:var(--r-full);text-transform:none;margin-left:var(--sp-8);vertical-align:middle}
+#feedbadge.on{display:inline-flex;align-items:center;gap:6px}
+#feedbadge .d{width:7px;height:7px;border-radius:var(--r-full);background:var(--c-final);animation:pulse 1.1s infinite}
+.minute{color:var(--c-live);font-weight:800;font-size:var(--fs-2xs);font-variant-numeric:tabular-nums}
 /* ============ Live strip + countdowns ============ */
 .livestrip{display:grid;grid-template-columns:1fr 1fr;gap:var(--sp-12);margin-top:var(--sp-20)}
 .lcard{border:1px solid var(--line);border-radius:var(--r-lg);padding:var(--sp-14) var(--sp-16);background:linear-gradient(180deg,var(--card),var(--card2));display:flex;align-items:center;gap:var(--sp-12);box-shadow:var(--shadow)}
@@ -285,7 +292,7 @@ footer .srcs a:hover{text-decoration:underline}
 <div class="wrap">
   <!-- HERO -->
   <section class="hero">
-    <div class="eyebrow">The complete brief · Round of 32</div>
+    <div class="eyebrow">The complete brief · Round of 32 <span id="feedbadge"></span></div>
     <h1>The first <span class="grad">48-team</span> World Cup is in the knockouts.</h1>
     <p>Group stage done, records already shattered — and the bracket is biting. Germany and the
        Netherlands are already out on penalties; Canada, Brazil, Paraguay and Morocco are through.
@@ -566,18 +573,19 @@ const teamHTML = (t)=>`<span class="team"><img class="flag" loading="lazy" src="
 // Bracket — split into two columns of 8 ties
 function renderBracket(){
   const wrap=document.getElementById('bracket');
+  wrap.innerHTML='';
   const cols=[MATCHES.slice(0,8),MATCHES.slice(8)];
   cols.forEach((col,ci)=>{
     const c=el(`<div class="brk-col"><h3>${ci===0?'Top half':'Bottom half'}</h3></div>`);
     col.forEach(m=>{
-      const s=statusOf(m),done=s==='final';
+      const s=statusOf(m),done=s==='final',lv=m._live,showScore=done||!!lv;
       const aWin=done&&m.w==='a', bWin=done&&m.w==='b';
-      const sa=m.as??'', sb=m.bs??'';
+      const sa=done?m.as:(lv?lv.as:''), sb=done?m.bs:(lv?lv.bs:'');
       const foot=done?('✓ '+m.next+(m.pen?` · 1–1 (${m.pen} pens)`:''))
-               : s==='live'||s==='await'?'● In play':m.d;
+               : (s==='live'||s==='await')?('● In play'+(lv&&lv.minute!=null?` · ${lv.minute}'`:'')):m.d;
       c.appendChild(el(`<div class="tie">
-        <div class="tie-row ${aWin?'won':done?'lost':''}"><img class="flag" src="${F(m.a.code)}" onerror="this.style.visibility='hidden'"><span class="nm">${m.a.name}</span><span class="sc">${done?sa:''}</span></div>
-        <div class="tie-row ${bWin?'won':done?'lost':''}"><img class="flag" src="${F(m.b.code)}" onerror="this.style.visibility='hidden'"><span class="nm">${m.b.name}</span><span class="sc">${done?sb:''}</span></div>
+        <div class="tie-row ${aWin?'won':done?'lost':''}"><img class="flag" src="${F(m.a.code)}" onerror="this.style.visibility='hidden'"><span class="nm">${m.a.name}</span><span class="sc">${showScore?sa:''}</span></div>
+        <div class="tie-row ${bWin?'won':done?'lost':''}"><img class="flag" src="${F(m.b.code)}" onerror="this.style.visibility='hidden'"><span class="nm">${m.b.name}</span><span class="sc">${showScore?sb:''}</span></div>
         <div class="tie-foot">${foot}</div>
       </div>`));
     });
@@ -586,9 +594,9 @@ function renderBracket(){
 }
 
 function statusPill(m){
-  const s=statusOf(m);
+  const s=statusOf(m),lv=m._live;
   if(s==='final')return `<span class="pill final"><span class="dot"></span>Final</span>`;
-  if(s==='live')return `<span class="pill live"><span class="dot"></span>Live</span>`;
+  if(s==='live')return `<span class="pill live"><span class="dot"></span>Live${lv&&lv.minute!=null?` ${lv.minute}'`:''}</span>`;
   if(s==='await')return `<span class="pill live"><span class="dot"></span>In play</span>`;
   return `<span class="pill sched"><span class="dot"></span>Scheduled</span>`;
 }
@@ -596,8 +604,11 @@ function renderMatches(filter='all'){
   const list=document.getElementById('matchlist');list.innerHTML='';
   MATCHES.filter(m=>{const s=statusOf(m);return filter==='all'||s===filter||(filter==='live'&&s==='await');}).forEach(m=>{
     const s=statusOf(m),done=s==='final',inplay=(s==='live'||s==='await');
-    const scoreA=done?`<span class="score ${m.w==='a'?'win':''}">${m.as}</span>`:'';
-    const scoreB=done?`<span class="score ${m.w==='b'?'win':''}">${m.bs}</span>`:'';
+    const lv=m._live,showScore=done||(inplay&&lv);
+    const dA=done?m.as:(lv?lv.as:''),dB=done?m.bs:(lv?lv.bs:'');
+    const scoreA=showScore?`<span class="score ${done&&m.w==='a'?'win':''}">${dA}</span>`:'';
+    const scoreB=showScore?`<span class="score ${done&&m.w==='b'?'win':''}">${dB}</span>`:'';
+    const mid=showScore?(inplay&&lv&&lv.minute!=null?`<span class="minute">${lv.minute}'</span>`:'<span class="vs">–</span>'):`<span class="vs">vs</span>`;
     const penTxt=done&&m.pen?`<span class="pennote">pens ${m.pen}</span>`:'';
     const cd=s==='sched'?`<span class="cdchip" data-ko="${m.t}">—</span>`:'';
     const link=inplay
@@ -605,7 +616,7 @@ function renderMatches(filter='all'){
       :`<a class="watch" href="${m.v}" target="_blank" rel="noopener"><svg class="icon sm" viewBox="0 0 24 24"><path d="M5 3l14 9-14 9z"/></svg>${done?'Highlights':'Preview'}</a>`;
     list.appendChild(el(`<div class="match">
       <div class="when">${m.d}</div>
-      <div class="teams">${teamHTML(m.a)}${scoreA}<span class="vs">${done?'':'vs'}</span>${scoreB}${teamHTML(m.b)}${penTxt}</div>
+      <div class="teams">${teamHTML(m.a)}${scoreA}${mid}${scoreB}${teamHTML(m.b)}${penTxt}</div>
       <div class="right">${statusPill(m)}${cd}${link}<span class="next">${m.next}</span></div>
     </div>`));
   });
@@ -661,11 +672,50 @@ document.getElementById('themeBtn').addEventListener('click',()=>{
 });
 
 /* ===================== FILTERS ===================== */
+let curFilter='all';
 document.getElementById('filters').addEventListener('click',e=>{
   const b=e.target.closest('.fpill');if(!b)return;
+  curFilter=b.dataset.f;
   document.querySelectorAll('.fpill').forEach(p=>p.classList.toggle('active',p===b));
-  renderMatches(b.dataset.f);
+  renderMatches(curFilter);
 });
+
+/* ===================== LIVE FEED (api/scores) ===================== */
+// Merge server-normalized live data into MATCHES, handling home/away orientation.
+function applyLive(list){
+  let changed=false;
+  list.forEach(d=>{
+    let m=MATCHES.find(x=>x.a.code===d.a&&x.b.code===d.b), rev=false;
+    if(!m){m=MATCHES.find(x=>x.a.code===d.b&&x.b.code===d.a);rev=true;}
+    if(!m)return;
+    const sA=rev?d.scoreB:d.scoreA, sB=rev?d.scoreA:d.scoreB;
+    const win=d.winner?(rev?(d.winner==='a'?'b':'a'):d.winner):null;
+    const pens=d.pens?(rev?d.pens.split('–').reverse().join('–'):d.pens):null;
+    if(d.status==='final'){
+      if(m.st!=='final'||m.as!==sA||m.bs!==sB)changed=true;
+      m.st='final';m.as=sA;m.bs=sB;if(pens)m.pen=pens;if(win)m.w=win;delete m._live;
+    }else if(d.status==='live'){
+      const prev=m._live;
+      if(!prev||prev.as!==sA||prev.bs!==sB||prev.minute!==d.minute)changed=true;
+      m._live={as:sA,bs:sB,minute:d.minute};
+    }
+  });
+  return changed;
+}
+const hhmmss=ms=>new Intl.DateTimeFormat('en-GB',{timeZone:'Asia/Kolkata',hour:'2-digit',minute:'2-digit',second:'2-digit',hour12:false}).format(new Date(ms));
+async function pollLive(){
+  const badge=document.getElementById('feedbadge');
+  try{
+    const r=await fetch('api/scores',{cache:'no-store'});
+    if(!r.ok)return;
+    const j=await r.json();
+    if(j.source==='api'&&Array.isArray(j.matches)&&j.matches.length){
+      const changed=applyLive(j.matches);
+      if(changed){renderBracket();renderMatches(curFilter);renderLiveStrip();tick();}
+      if(badge){badge.className='on';badge.innerHTML=`<span class="d"></span>LIVE DATA · updated ${hhmmss(new Date(j.updated).getTime())}`;}
+    }else if(badge){badge.className='';} // snapshot/stale → keep curated data, hide badge
+  }catch(e){/* network error → keep snapshot silently */}
+}
 
 /* ===================== LIVE ENGINE ===================== */
 const pad=n=>String(n).padStart(2,'0');
@@ -684,9 +734,11 @@ function renderLiveStrip(){
   const box=document.getElementById('livestrip');if(!box)return;
   const lv=liveMatch(),nx=nextMatch();
   let html='';
-  if(lv){html+=`<div class="lcard islive"><span class="livedot"></span><div class="grow1">
-    <div class="llabel">Live now</div>
-    <div class="lmatch"><img class="flag" src="${F(lv.a.code)}" onerror="this.style.visibility='hidden'">${lv.a.name} vs ${lv.b.name}<img class="flag" src="${F(lv.b.code)}" onerror="this.style.visibility='hidden'"></div>
+  if(lv){const ld=lv._live;
+    const sc=ld?`<b>${ld.as}–${ld.bs}</b>`:'vs';
+    html+=`<div class="lcard islive"><span class="livedot"></span><div class="grow1">
+    <div class="llabel">Live now${ld&&ld.minute!=null?` · ${ld.minute}'`:''}</div>
+    <div class="lmatch"><img class="flag" src="${F(lv.a.code)}" onerror="this.style.visibility='hidden'">${lv.a.name} ${sc} ${lv.b.name}<img class="flag" src="${F(lv.b.code)}" onerror="this.style.visibility='hidden'"></div>
     <div class="lsub">In play · <a href="${lv.v}" target="_blank" rel="noopener">follow live ↗</a></div></div></div>`;}
   else{const lf=latestFinal();if(lf)html+=`<div class="lcard"><div class="grow1">
     <div class="llabel">Latest result</div>
@@ -763,6 +815,8 @@ if('serviceWorker'in navigator){window.addEventListener('load',()=>navigator.ser
   // live engine
   renderLiveStrip();lastNextId=(nextMatch()||{}).t||'';
   tick();setInterval(tick,1000);setInterval(maybeRerenderStrip,30000);
+  // live score feed (graceful no-op when no match is live / no API key configured)
+  pollLive();setInterval(pollLive,45000);
   // restore alerts preference (re-arms timers; system permission may already be granted)
   try{if(localStorage.getItem(ALERT_KEY)==='1'&&(!('Notification'in window)||Notification.permission==='granted'))setAlerts(true);}catch(e){}
 })();


### PR DESCRIPTION
Adds an **optional real-time live-score feed** to the dashboard (follow-up to #91/#92, both merged). Off until an API key is configured — the page works fully on the curated snapshot without it.

## What's added
- **`api/scores.js`** — a Vercel serverless function proxying **API-Football** (api-sports.io):
  - Key stays **server-side** (`process.env.FOOTBALL_API_KEY`), never shipped to the browser.
  - **Schedule-gated** — only calls upstream when a fixture is inside its live window; **zero** calls when idle.
  - **CDN-cached** (`Cache-Control: s-maxage`) so many users → ≤1 upstream call per ~120s while live — keeps us within the 100-req/day free tier.
  - **Fails safe** — any error / missing key / rate-limit returns `{source:'stale'}` and the client keeps the snapshot. The page never breaks.
  - Normalizes fixtures, maps API team names → our flag codes, handles home/away orientation + penalty results.
- **`index.html`** — `pollLive()` fetches `api/scores` (~45s), merges live results into `MATCHES` by team-code key, re-renders the bracket / match board / live strip with **live score + match minute**, and shows a **"LIVE DATA · updated HH:MM:SS"** badge. Silent fallback on stale/error.

## Verification
- Function logic covered by local tests: name mapping, penalty parsing, status mapping, 429/rate-limit fallback, idle (no upstream call), unmapped-team skip — all pass.
- Live render verified end-to-end with a simulated in-play match (badge + live score + minute render correctly; next-kickoff advances).

## To enable (one-time, user side)
1. Free key at https://www.api-sports.io/
2. Vercel → project **codex** → Settings → Environment Variables → add `FOOTBALL_API_KEY` (Production + Preview), redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqHBqPtZ7v7jMj1YnzCyBr)_